### PR TITLE
Use explicit arguments in download() functions

### DIFF
--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -101,7 +101,7 @@ def common_script_arguments(parser):    # pragma: no cover
     return parser
 
 
-def common_auth_arguments(parser):
+def common_auth_arguments(parser):     # pragma: no cover
     parser.add_argument('--auth',
                         help="Yaml file with plaintext usernames/passwords")
     parser.add_argument('--auth_key',

--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -101,6 +101,21 @@ def common_script_arguments(parser):    # pragma: no cover
     return parser
 
 
+def common_auth_arguments(parser):
+    parser.add_argument('--auth',
+                        help="Yaml file with plaintext usernames/passwords")
+    parser.add_argument('--auth_key',
+                        help=("Top level key which user/pass are stored in "
+                              "yaml file."))
+    parser.add_argument('--username',
+                        help=("The username for data requests. Overrides auth "
+                              "file."))
+    parser.add_argument('--password',
+                        help=("The password for data requests. Overrides auth "
+                              "file."))
+    return parser
+
+
 def setup_logging(log_conf, log, error_email, log_level, name):
     log_c = yaml.load(log_conf)
     if log:

--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -102,7 +102,7 @@ def common_script_arguments(parser):    # pragma: no cover
 
 
 def common_auth_arguments(parser):     # pragma: no cover
-    parser.add_argument('--auth',
+    parser.add_argument('--auth_fname',
                         help="Yaml file with plaintext usernames/passwords")
     parser.add_argument('--auth_key',
                         help=("Top level key which user/pass are stored in "

--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -147,7 +147,8 @@ def iterable_to_stream(iterable, buffer_size=io.DEFAULT_BUFFER_SIZE):
     return io.BufferedReader(IterStream(), buffer_size=buffer_size)
 
 
-def run_data_pipeline(download_func, normalize_func, download_args):
+def run_data_pipeline(download_func, normalize_func, download_args,
+                      cache_file):
     '''Executes all stages of the data processing pipeline.
 
        Downloads the data, according to the download arguments
@@ -157,12 +158,11 @@ def run_data_pipeline(download_func, normalize_func, download_args):
        pipeline.
 
     '''
-    args = download_args
-    download_iter = download_func(args)
+    download_iter = download_func(**download_args)
 
-    if args.cache_file:
+    if cache_file:
         download_iter, cache_iter = tee(download_iter)
-        with open(args.cache_file, 'w') as f:
+        with open(cache_file, 'w') as f:
             for chunk in cache_iter:
                 f.write(chunk)
 
@@ -171,3 +171,7 @@ def run_data_pipeline(download_func, normalize_func, download_args):
         print(row)
     # observations = [align(row) for row in rows]
     # insert(observations)
+
+
+def subset_dict(a_dict, keys_wanted):
+    return {key: a_dict[key] for key in keys_wanted if key in a_dict}

--- a/crmprtd/download.py
+++ b/crmprtd/download.py
@@ -102,20 +102,25 @@ class FTPReader(object):
             self.connection.close()
 
 
-def extract_auth(username, password, auth_file, auth_key):
+def extract_auth(username, password, auth_yaml, auth_key):
     '''Extract auth information
 
     Use either the username/password provided or pull the info out from the
     provided yaml file
     '''
+    def none_to_empty_string(s):
+        return s if s else ''
+
     if username or password:
-        return {'u': username, 'p': password}
+        return {
+            'u': none_to_empty_string(username),
+            'p': none_to_empty_string(password)
+        }
     else:
-        assert auth_file and auth_key, ("Must provide both the auth file "
+        assert auth_yaml and auth_key, ("Must provide both the auth file "
                                         "and the key to use for this "
                                         "script (--auth_key)")
-        with open(auth_file, 'r') as f:
-            config = yaml.load(f)
+        config = yaml.load(auth_yaml)
         return {
             'u': config[auth_key]['username'],
             'p': config[auth_key]['password']

--- a/crmprtd/download.py
+++ b/crmprtd/download.py
@@ -5,6 +5,8 @@ import logging
 import csv
 from functools import wraps
 
+import yaml
+
 
 def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
     """Retry calling the decorated function using an exponential backoff.
@@ -98,3 +100,23 @@ class FTPReader(object):
             self.connection.quit()
         except Exception:
             self.connection.close()
+
+
+def extract_auth(username, password, auth_file, auth_key):
+    '''Extract auth information
+
+    Use either the username/password provided or pull the info out from the
+    provided yaml file
+    '''
+    if username or password:
+        return {'u': username, 'p': password}
+    else:
+        assert auth_file and auth_key, ("Must provide both the auth file "
+                                        "and the key to use for this "
+                                        "script (--auth_key)")
+        with open(auth_file, 'r') as f:
+            config = yaml.load(f)
+        return {
+            'u': config[auth_key]['username'],
+            'p': config[auth_key]['password']
+        }

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -13,22 +13,22 @@ from crmprtd.ec import makeurl
 log = logging.getLogger(__name__)
 
 
-def download(args):
+def download(time, frequency, province, language):
     log.info('Starting EC rtd')
 
     try:
         # Determine time parameter
-        if args.time:
-            args.time = datetime.strptime(args.time, '%Y/%m/%d %H:%M:%S')
+        if time:
+            time = datetime.strptime(time, '%Y/%m/%d %H:%M:%S')
             log.info("Starting manual run "
-                     "using timestamp {0}".format(args.time))
+                     "using timestamp {0}".format(time))
         else:
             # go back a day
             deltat = timedelta(
-                1 / 24.) if args.frequency == 'hourly' else timedelta(1)
-            args.time = datetime.utcnow() - deltat
+                1 / 24.) if frequency == 'hourly' else timedelta(1)
+            time = datetime.utcnow() - deltat
             log.info("Starting automatic run "
-                     "using timestamp {0}".format(args.time))
+                     "using timestamp {0}".format(time))
 
         # Configure requests to use retry
         s = requests.Session()
@@ -36,7 +36,7 @@ def download(args):
         s.mount('https://', a)
 
         # Construct and download the xml
-        url = makeurl(args.frequency, args.province, args.language, args.time)
+        url = makeurl(frequency, province, language, time)
 
         log.info("Downloading {0}".format(url))
         req = s.get(url)

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -15,12 +15,13 @@ from crmprtd.download import extract_auth
 log = logging.getLogger(__name__)
 
 
-def download(username, password, auth, auth_key,
+def download(username, password, auth_fname, auth_key,
              start_time, end_time, station_id):
     log.info('Starting MOTIe rtd')
 
     try:
-        auth = extract_auth(username, password, auth, auth_key)
+        auth_yaml = open(auth_fname, 'r').read() if auth_fname else None
+        auth = extract_auth(username, password, auth_yaml, auth_key)
 
         if start_time and end_time:
             start_time = datetime.strptime(

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -14,14 +14,14 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-def download(bciduser, bcidpass, auth, auth_key,
+def download(username, password, auth, auth_key,
              start_time, end_time, station_id):
     log.info('Starting MOTIe rtd')
 
     try:
         # Pull auth from file or command line
-        if bciduser or bcidpass:
-            auth = (bciduser, bcidpass)
+        if username or password:
+            auth = (username, password)
         else:
             assert auth and auth_key, ("Must provide both the auth "
                                        "file and the key to use for "

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -14,42 +14,43 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-def download(args):
+def download(bciduser, bcidpass, auth, auth_key,
+             start_time, end_time, station_id):
     log.info('Starting MOTIe rtd')
 
     try:
         # Pull auth from file or command line
-        if args.bciduser or args.bcidpass:
-            auth = (args.bciduser, args.bcidpass)
+        if bciduser or bcidpass:
+            auth = (bciduser, bcidpass)
         else:
-            assert args.auth and args.auth_key, ("Must provide both the auth "
-                                                 "file and the key to use for "
-                                                 "this script (--auth_key)")
-            with open(args.auth, 'r') as f:
+            assert auth and auth_key, ("Must provide both the auth "
+                                       "file and the key to use for "
+                                       "this script (--auth_key)")
+            with open(auth, 'r') as f:
                 config = yaml.load(f)
-            auth = (config[args.auth_key]['username'],
-                    config[args.auth_key]['password'])
+            auth = (config[auth_key]['username'],
+                    config[auth_key]['password'])
 
-        if args.start_time and args.end_time:
-            args.start_time = datetime.strptime(
-                args.start_time, '%Y/%m/%d %H:%M:%S')
-            args.end_time = datetime.strptime(
-                args.end_time, '%Y/%m/%d %H:%M:%S')
+        if start_time and end_time:
+            start_time = datetime.strptime(
+                start_time, '%Y/%m/%d %H:%M:%S')
+            end_time = datetime.strptime(
+                end_time, '%Y/%m/%d %H:%M:%S')
             log.info("Starting manual run using timestamps {0} {1}".format(
-                args.start_time, args.end_time))
+                start_time, end_time))
             # Requests of longer than 7 days not allowed by MoTI
-            assert args.end_time - args.start_time <= timedelta(7)
+            assert end_time - start_time <= timedelta(7)
         else:
             deltat = timedelta(1)  # go back a day
-            args.start_time = datetime.utcnow() - deltat
-            args.end_time = datetime.utcnow()
+            start_time = datetime.utcnow() - deltat
+            end_time = datetime.utcnow()
             log.info("Starting automatic run "
-                     "using timestamps {0} {1}".format(args.start_time,
-                                                       args.end_time))
+                     "using timestamps {0} {1}".format(start_time,
+                                                       end_time))
 
-        if args.station_id:
-            payload = {'request': 'historic', 'station': args.station_id,
-                       'from': args.start_time, 'to': args.end_time}
+        if station_id:
+            payload = {'request': 'historic', 'station': station_id,
+                       'from': start_time, 'to': end_time}
         else:
             payload = {}
 

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -12,12 +12,12 @@ from crmprtd.download import FTPReader
 log = logging.getLogger(__name__)
 
 
-def download(args):
+def download(ftp_server, ftp_dir):
     log.info('Starting WAMR rtd')
 
     try:
         # Connect FTP server and retrieve file
-        ftpreader = ftp_connect(WAMRFTPReader, args.ftp_server, args.ftp_dir,
+        ftpreader = ftp_connect(WAMRFTPReader, ftp_server, ftp_dir,
                                 log)
 
         with SpooledTemporaryFile(

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -13,10 +13,11 @@ from crmprtd.download import FTPReader, extract_auth
 log = logging.getLogger(__name__)
 
 
-def download(username, password, auth, auth_key, ftp_server, ftp_file):
+def download(username, password, auth_fname, auth_key, ftp_server, ftp_file):
     log.info('Starting WMB rtd')
 
-    auth = extract_auth(username, password, auth, auth_key)
+    auth_yaml = open(auth_fname, 'r').read() if auth_fname else None
+    auth = extract_auth(username, password, auth_yaml, auth_key)
 
     try:
         # Connect FTP server and retrieve file

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -16,24 +16,24 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-def download(args):
+def download(username, password, auth, auth_key, ftp_server, ftp_file):
     log.info('Starting WMB rtd')
 
     # Pull auth from args
-    if args.username or args.password:
-        auth = {'u': args.username, 'p': args.password}
+    if username or password:
+        auth = {'u': username, 'p': password}
     else:
-        assert args.auth and args.auth_key, ("Must provide both the auth file "
-                                             "and the key to use for this "
-                                             "script (--auth_key)")
-        with open(args.auth, 'r') as f:
+        assert auth and auth_key, ("Must provide both the auth file "
+                                   "and the key to use for this "
+                                   "script (--auth_key)")
+        with open(auth, 'r') as f:
             config = yaml.load(f)
-        auth = {'u': config[args.auth_key]['username'],
-                'p': config[args.auth_key]['password']}
+        auth = {'u': config[auth_key]['username'],
+                'p': config[auth_key]['password']}
 
     try:
         # Connect FTP server and retrieve file
-        ftpreader = ftp_connect(WMBFTPReader, args.ftp_server, args.ftp_file,
+        ftpreader = ftp_connect(WMBFTPReader, ftp_server, ftp_file,
                                 log, auth)
 
         with SpooledTemporaryFile(

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -7,10 +7,7 @@ from tempfile import SpooledTemporaryFile
 
 # Local
 from crmprtd.download import retry, ftp_connect
-from crmprtd.download import FTPReader
-
-# Installed libraries
-import yaml
+from crmprtd.download import FTPReader, extract_auth
 
 
 log = logging.getLogger(__name__)
@@ -19,17 +16,7 @@ log = logging.getLogger(__name__)
 def download(username, password, auth, auth_key, ftp_server, ftp_file):
     log.info('Starting WMB rtd')
 
-    # Pull auth from args
-    if username or password:
-        auth = {'u': username, 'p': password}
-    else:
-        assert auth and auth_key, ("Must provide both the auth file "
-                                   "and the key to use for this "
-                                   "script (--auth_key)")
-        with open(auth, 'r') as f:
-            config = yaml.load(f)
-        auth = {'u': config[auth_key]['username'],
-                'p': config[auth_key]['password']}
+    auth = extract_auth(username, password, auth, auth_key)
 
     try:
         # Connect FTP server and retrieve file

--- a/scripts/hourly_wmb.py
+++ b/scripts/hourly_wmb.py
@@ -13,7 +13,8 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.wmb.download import download
 from crmprtd.wmb.normalize import normalize
-from crmprtd import common_script_arguments, setup_logging, run_data_pipeline
+from crmprtd import common_script_arguments, setup_logging, run_data_pipeline,\
+    subset_dict
 
 
 if __name__ == '__main__':
@@ -42,4 +43,8 @@ if __name__ == '__main__':
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.wmb')
 
-    run_data_pipeline(download, normalize, args)
+    dl_args = ['username', 'password', 'auth', 'auth_key', 'ftp_server',
+               'ftp_file']
+    dl_args = subset_dict(vars(args), dl_args)
+
+    run_data_pipeline(download, normalize, dl_args, args.cache_file)

--- a/scripts/hourly_wmb.py
+++ b/scripts/hourly_wmb.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.wmb')
 
-    dl_args = ['username', 'password', 'auth', 'auth_key', 'ftp_server',
+    dl_args = ['username', 'password', 'auth_fname', 'auth_key', 'ftp_server',
                'ftp_file']
     dl_args = subset_dict(vars(args), dl_args)
 

--- a/scripts/hourly_wmb.py
+++ b/scripts/hourly_wmb.py
@@ -13,8 +13,8 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.wmb.download import download
 from crmprtd.wmb.normalize import normalize
-from crmprtd import common_script_arguments, setup_logging, run_data_pipeline,\
-    subset_dict
+from crmprtd import common_script_arguments, common_auth_arguments, \
+    setup_logging, run_data_pipeline, subset_dict
 
 
 if __name__ == '__main__':
@@ -27,18 +27,8 @@ if __name__ == '__main__':
                         default='HourlyWeatherAllFields_WA.txt',
                         help=('Filename to open on the Wildfire Management '
                               'Branch\'s ftp site'))
-    parser.add_argument('--auth',
-                        help="Yaml file with plaintext usernames/passwords")
-    parser.add_argument('--auth_key',
-                        help=("Top level key which user/pass are stored in "
-                              "yaml file."))
-    parser.add_argument('--username',
-                        help=("The username for data requests. Overrides auth "
-                              "file."))
-    parser.add_argument('--password',
-                        help=("The password for data requests. Overrides auth "
-                              "file."))
     parser = common_script_arguments(parser)
+    parser = common_auth_arguments(parser)
     args = parser.parse_args()
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.wmb')

--- a/scripts/moti_hourly.py
+++ b/scripts/moti_hourly.py
@@ -6,8 +6,8 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.moti.download import download
 from crmprtd.moti.normalize import normalize
-from crmprtd import common_script_arguments, setup_logging, run_data_pipeline,\
-    subset_dict
+from crmprtd import common_script_arguments, common_auth_arguments, \
+    setup_logging, run_data_pipeline, subset_dict
 
 
 if __name__ == '__main__':
@@ -22,24 +22,14 @@ if __name__ == '__main__':
                               "strptime(format='Y/m/d H:M:S')"))
     parser.add_argument('-s', '--station_id',
                         help="Station ID for which to download data")
-    parser.add_argument('--auth',
-                        help="Yaml file with plaintext usernames/passwords")
-    parser.add_argument('--auth_key',
-                        help=("Top level key which user/pass are stored in "
-                              "yaml file."))
-    parser.add_argument('--bciduser',
-                        help=("The BCID username for data requests. Overrides "
-                              "auth file."))
-    parser.add_argument('--bcidpass',
-                        help=("The BCID password for data requests. Overrides "
-                              "auth file."))
     parser = common_script_arguments(parser)
+    parser = common_auth_arguments(parser)
     args = parser.parse_args()
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.moti')
 
     dl_args = ['start_time', 'end_time', 'station_id', 'auth',
-               'auth_key', 'bciduser', 'bcidpass']
+               'auth_key', 'username', 'password']
     dl_args = subset_dict(vars(args), dl_args)
 
     run_data_pipeline(download, normalize, dl_args, args.cache_file)

--- a/scripts/moti_hourly.py
+++ b/scripts/moti_hourly.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.moti')
 
-    dl_args = ['start_time', 'end_time', 'station_id', 'auth',
+    dl_args = ['start_time', 'end_time', 'station_id', 'auth_fname',
                'auth_key', 'username', 'password']
     dl_args = subset_dict(vars(args), dl_args)
 

--- a/scripts/moti_hourly.py
+++ b/scripts/moti_hourly.py
@@ -6,7 +6,8 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.moti.download import download
 from crmprtd.moti.normalize import normalize
-from crmprtd import common_script_arguments, setup_logging, run_data_pipeline
+from crmprtd import common_script_arguments, setup_logging, run_data_pipeline,\
+    subset_dict
 
 
 if __name__ == '__main__':
@@ -37,4 +38,8 @@ if __name__ == '__main__':
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.moti')
 
-    run_data_pipeline(download, normalize, args)
+    dl_args = ['start_time', 'end_time', 'station_id', 'auth',
+               'auth_key', 'bciduser', 'bcidpass']
+    dl_args = subset_dict(vars(args), dl_args)
+
+    run_data_pipeline(download, normalize, dl_args, args.cache_file)

--- a/scripts/real_time_ec.py
+++ b/scripts/real_time_ec.py
@@ -6,7 +6,8 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.ec.download import download
 from crmprtd.ec.normalize import normalize
-from crmprtd import common_script_arguments, setup_logging, run_data_pipeline
+from crmprtd import common_script_arguments, setup_logging, run_data_pipeline,\
+    subset_dict
 
 
 if __name__ == '__main__':
@@ -33,4 +34,7 @@ if __name__ == '__main__':
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.ec')
 
-    run_data_pipeline(download, normalize, args)
+    dl_args = ['time', 'frequency', 'province', 'language']
+    dl_args = subset_dict(vars(args), dl_args)
+
+    run_data_pipeline(download, normalize, dl_args, args.cache_file)

--- a/scripts/wamr_hourly.py
+++ b/scripts/wamr_hourly.py
@@ -14,7 +14,8 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.wamr.download import download
 from crmprtd.wamr.normalize import normalize
-from crmprtd import common_script_arguments, setup_logging, run_data_pipeline
+from crmprtd import common_script_arguments, setup_logging, run_data_pipeline,\
+    subset_dict
 
 
 if __name__ == '__main__':
@@ -33,4 +34,7 @@ if __name__ == '__main__':
     log = setup_logging(args.log_conf, args.log,
                         args.error_email, args.log_level, 'crmprtd.wamr')
 
-    run_data_pipeline(download, normalize, args)
+    dl_args = ['ftp_server', 'ftp_dir']
+    dl_args = subset_dict(vars(args), dl_args)
+
+    run_data_pipeline(download, normalize, dl_args, args.cache_file)

--- a/tests/test_crmprtd.py
+++ b/tests/test_crmprtd.py
@@ -1,0 +1,11 @@
+import pytest
+
+from crmprtd import subset_dict
+
+@pytest.mark.parametrize(('a_dict', 'keys', 'expected'), (
+    ({'a': 'b', 'c': 'd', 'e': 'f'}, ['a', 'e'], {'a': 'b', 'e': 'f'}),
+    ({'a': 'b'}, ['a'], {'a': 'b'}),
+    ({'a': 'b'}, ['c'], {}),
+))
+def test_subset_dict(a_dict, keys, expected):
+    assert subset_dict(a_dict, keys) == expected

--- a/tests/test_crmprtd.py
+++ b/tests/test_crmprtd.py
@@ -2,6 +2,7 @@ import pytest
 
 from crmprtd import subset_dict
 
+
 @pytest.mark.parametrize(('a_dict', 'keys', 'expected'), (
     ({'a': 'b', 'c': 'd', 'e': 'f'}, ['a', 'e'], {'a': 'b', 'e': 'f'}),
     ({'a': 'b'}, ['a'], {'a': 'b'}),

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,17 @@
+import pytest
+
+from crmprtd.download import extract_auth
+
+
+@pytest.mark.parametrize(('user', 'password', 'expected'), (
+    ('foo', 'bar', {'u': 'foo', 'p': 'bar'}),
+    ('foo', None, {'u': 'foo', 'p': ''}),
+    (None, 'bar', {'u': '', 'p': 'bar'}),
+    (None, None, {'u': 'user_from_file', 'p': 'pw_from_file'})
+))
+def test_extract_auth(user, password, expected):
+    yaml = '''my_test:
+  username: user_from_file
+  password: pw_from_file
+'''
+    assert extract_auth(user, password, yaml, 'my_test') == expected


### PR DESCRIPTION
Previously all of the various download functions would only accept a namespace argument named "args" (which comes from the argparse module and command line argument processing). It was up to the developer to actually read through the code to figure out what arguments need to be supplied. This PR makes all of the argument lists explicit and modifies the calling scripts to pass them through.