### PR TITLE
Feature input file

### DIFF
--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -63,6 +63,27 @@ Row = namedtuple('Row', "time val variable_name unit network_name \
                          station_id lat lon")
 
 
+def logging_args(parser):
+    parser.add_argument('-L', '--log_conf',
+                        default=None,
+                        help=('YAML file to use to override the default '
+                              'logging configuration'))
+    parser.add_argument('-l', '--log_filename',
+                        default=None,
+                        help='Override the default log filename')
+    parser.add_argument('-o', '--log_level',
+                        choices=['DEBUG', 'INFO',
+                                 'WARNING', 'ERROR', 'CRITICAL'],
+                        help=('Set log level: DEBUG, INFO, WARNING, ERROR, '
+                              'CRITICAL.  Note that debug output by default '
+                              'goes directly to file'))
+    parser.add_argument('-m', '--error_email',
+                        default=None,
+                        help=('Override the default e-mail address to which '
+                              'the program should report critical errors'))
+    return parser
+
+
 def common_script_arguments(parser):    # pragma: no cover
     parser.add_argument('-c', '--connection_string',
                         help='PostgreSQL connection string')

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -4,7 +4,6 @@ import logging
 import logging.config
 from datetime import datetime, timedelta
 from argparse import ArgumentParser
-import pickle
 
 # Installed libraries
 import requests
@@ -47,9 +46,8 @@ def download(time, frequency, province, language):
             raise IOError(
                 "HTTP {} error for {}".format(req.status_code, req.url))
 
-        pickle.dump('Network module name: ec', sys.stdout.buffer)
         for line in req.iter_content(chunk_size=None):
-            pickle.dump(line, sys.stdout.buffer)
+            sys.stdout.buffer.write(line)
 
     except IOError:
         log.exception("Unable to download or open xml data")

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -3,12 +3,15 @@ import sys
 import logging
 import logging.config
 from datetime import datetime, timedelta
+from argparse import ArgumentParser
+import pickle
 
 # Installed libraries
 import requests
 
 # Local
 from crmprtd.ec import makeurl
+from crmprtd import common_script_arguments, setup_logging, logging_args
 
 log = logging.getLogger(__name__)
 
@@ -43,8 +46,39 @@ def download(time, frequency, province, language):
         if req.status_code != 200:
             raise IOError(
                 "HTTP {} error for {}".format(req.status_code, req.url))
-        return req.iter_content(chunk_size=None)
+
+        pickle.dump('Network module name: ec', sys.stdout.buffer)
+        for line in req.iter_content(chunk_size=None):
+            pickle.dump(line, sys.stdout.buffer)
 
     except IOError:
         log.exception("Unable to download or open xml data")
         sys.exit(1)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('-p', '--province', required=True,
+                        help='2 letter province code')
+    parser.add_argument('-g', '--language', default='e',
+                        choices=['e', 'f'],
+                        help="'e' (english) | 'f' (french)")
+    parser.add_argument('-F', '--frequency', required=True,
+                        choices=['daily', 'hourly'],
+                        help='daily|hourly')
+    parser.add_argument('-t', '--time',
+                        help=("Alternate *UTC* time to use for downloading "
+                              "(interpreted using "
+                              "format=YYYY/MM/DD HH:MM:SS)"))
+    parser.add_argument('-T', '--threshold', default=1000,
+                        help=('Distance threshold to use when matching '
+                              'stations.  Stations are considered a match if '
+                              'they have the same id, name, and are within '
+                              'this threshold'))
+    parser = logging_args(parser)
+    args = parser.parse_args()
+
+    setup_logging(args.log_conf, args.log_filename, args.error_email,
+                  args.log_level, 'crmprtd.ec')
+
+    download(args.time, args.frequency, args.province, args.language)

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -11,7 +11,7 @@ import requests
 
 # Local
 from crmprtd.ec import makeurl
-from crmprtd import common_script_arguments, setup_logging, logging_args
+from crmprtd import setup_logging, logging_args
 
 log = logging.getLogger(__name__)
 

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -69,10 +69,10 @@ if __name__ == '__main__':
                               "(interpreted using "
                               "format=YYYY/MM/DD HH:MM:SS)"))
     parser.add_argument('-T', '--threshold', default=1000,
-                        help=('Distance threshold to use when matching '
-                              'stations.  Stations are considered a match if '
-                              'they have the same id, name, and are within '
-                              'this threshold'))
+                        help=('Distance threshold (in meters) to use when '
+                              'matching stations. Stations are considered a '
+                              'match if they have the same id, name, and are '
+                              'within this threshold'))
     parser = logging_args(parser)
     args = parser.parse_args()
 

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -5,12 +5,15 @@ import sys
 import logging
 import logging.config
 from datetime import datetime, timedelta
+from argparse import ArgumentParser
+import pickle
 
 # Installed libraries
 import requests
 
 # Local
 from crmprtd.download import extract_auth
+from crmprtd import common_auth_arguments, logging_args, setup_logging
 
 log = logging.getLogger(__name__)
 
@@ -58,8 +61,34 @@ def download(username, password, auth_fname, auth_key,
             raise IOError(
                 "HTTP {} error for {}".format(req.status_code, req.url))
 
-        return req.iter_content(chunk_size=None)
+        pickle.dump('Network module name: moti', sys.stdout.buffer)
+        for line in req.iter_content(chunk_size=None):
+            pickle.dump(line, sys.stdout.buffer)
 
     except IOError:
         log.exception("Unable to download or open xml data")
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser = logging_args(parser)
+    parser = common_auth_arguments(parser)
+    parser.add_argument('-S', '--start_time',
+                        help=("Alternate time to use for downloading "
+                              "(interpreted with "
+                              "strptime(format='Y/m/d H:M:S')"))
+    parser.add_argument('-E', '--end_time',
+                        help=("Alternate time to use for downloading "
+                              "(interpreted with "
+                              "strptime(format='Y/m/d H:M:S')"))
+    parser.add_argument('-s', '--station_id',
+                        default=None,
+                        help="Station ID for which to download data")
+    args = parser.parse_args()
+
+    setup_logging(args.log_conf, args.log_filename, args.error_email,
+                  args.log_level, 'crmprtd.moti')
+
+    download(args.username, args.password, args.auth_fname, args.auth_key,
+             args.start_time, args.end_time, args.station_id)

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -6,7 +6,6 @@ import logging
 import logging.config
 from datetime import datetime, timedelta
 from argparse import ArgumentParser
-import pickle
 
 # Installed libraries
 import requests
@@ -61,9 +60,8 @@ def download(username, password, auth_fname, auth_key,
             raise IOError(
                 "HTTP {} error for {}".format(req.status_code, req.url))
 
-        pickle.dump('Network module name: moti', sys.stdout.buffer)
         for line in req.iter_content(chunk_size=None):
-            pickle.dump(line, sys.stdout.buffer)
+            sys.stdout.buffer.write(line)
 
     except IOError:
         log.exception("Unable to download or open xml data")

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -66,6 +66,7 @@ def process(connection_string, sample_size):
        The the fuction send the normalized rows through the align
        and insert phases of the pipeline.
     '''
+    log = logging.getLogger('crmprtd')
     network = get_network()
     if network is None:
         log.error('No module name given, cannot continue pipeline',
@@ -83,8 +84,6 @@ def process(connection_string, sample_size):
 
     observations = [ob for ob in [align(sesh, row) for row in rows] if ob]
     results = insert(sesh, observations, sample_size)
-
-    log = logging.getLogger('crmprtd')
     log.info('Data insertion results', extra={'results': results})
 
 

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -24,21 +24,23 @@ def process_args(parser):
     return parser
 
 
-def get_stdin():
-    data = []
-    for line in sys.stdin:
-        # this retrieves the network name
-        if "Network module name:" in line:
-            line = line.strip('\n')
-            network = line[21:]
-        # allows logging from download phase
-        elif 'asctime' in line and 'levelname' in line:
-            line = line.strip('\n')
-            print(line)
-        else:
-            data.append(line)
+def get_network():
+    '''First line in stdout should contain a string with the network name.
+       This name corresponds to the module name that needs to be imported
+       dynamically.
+    '''
+    line = sys.stdin.readline()
+    if "Network module name:" in line:
+        line = line.strip('\n')
+        return line[21:]
+    else:
+        print('error no name given')
+        return None
 
-    return network, data
+
+def get_data():
+    for line in sys.stdin:
+        yield line
 
 
 def get_normalization_module(network):
@@ -52,7 +54,9 @@ def process(connection_string, sample_size):
        The the fuction send the normalized rows through the align
        and insert phases of the pipeline.
     '''
-    network, download_iter = get_stdin()
+    network = get_network()
+    download_iter = get_data()
+
     norm_mod = get_normalization_module(network)
 
     rows = [row for row in norm_mod.normalize(download_iter)]

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -23,6 +23,7 @@ def process_args(parser):
                              'when searching for duplicates '
                              'to determine which insertion strategy to use')
     parser.add_argument('-N', '--network',
+                        choices=['ec', 'moti', 'wamr', 'wmb'],
                         help='The network from which the data is coming from. '
                              'The name will be used for a dynamic import of '
                              'the module\'s normalization function.')

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -1,0 +1,76 @@
+import sys
+from importlib import import_module
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import logging
+from argparse import ArgumentParser
+
+from crmprtd.align import align
+from crmprtd.insert import insert
+
+
+def process_args(parser):
+    parser.add_argument('-c', '--connection_string',
+                        help='PostgreSQL connection string')
+    # FIXME: I do not think this arg gets used anywhere
+    parser.add_argument('-D', '--diag',
+                        default=False, action="store_true",
+                        help="Turn on diagnostic mode (no commits)")
+    parser.add_argument('--sample_size', type=int,
+                        default=50,
+                        help='Number of samples to be taken from observations '
+                             'when searching for duplicates '
+                             'to determine which insertion strategy to use')
+    return parser
+
+
+def get_stdin():
+    data = []
+    for line in sys.stdin:
+        # this retrieves the network name
+        if "Network module name:" in line:
+            line = line.strip('\n')
+            network = line[21:]
+        # allows logging from download phase
+        elif 'asctime' in line and 'levelname' in line:
+            line = line.strip('\n')
+            print(line)
+        else:
+            data.append(line)
+
+    return network, data
+
+
+def get_normalization_module(network):
+    return import_module('crmprtd.{}.normalize'.format(network))
+
+
+def process(connection_string, sample_size):
+    '''Executes 3 stages of the data processing pipeline.
+
+       Normalizes the data based on the network's format.
+       The the fuction send the normalized rows through the align
+       and insert phases of the pipeline.
+    '''
+    network, download_iter = get_stdin()
+    norm_mod = get_normalization_module(network)
+
+    rows = [row for row in norm_mod.normalize(download_iter)]
+
+    engine = create_engine(connection_string)
+    Session = sessionmaker(engine)
+    sesh = Session()
+
+    observations = [ob for ob in [align(sesh, row) for row in rows] if ob]
+    results = insert(sesh, observations, sample_size)
+
+    log = logging.getLogger(__name__)
+    log.info('Data insertion results', extra={'results': results})
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser = process_args(parser)
+    args = parser.parse_args()
+
+    process(args.connection_string, args.sample_size)

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -24,10 +24,6 @@ def download_args(parser):
                         default=('pub/outgoing/AIR/Hourly_Raw_Air_Data/'
                                  'Meteorological/'),
                         help='FTP Directory containing WAMR\'s data files')
-    parser.add_argument('--outfile',
-                        default=None,
-                        help='File where the ouput of download() will be '
-                             'printed')
     return parser
 
 

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -5,7 +5,6 @@ import sys
 
 from tempfile import SpooledTemporaryFile
 from argparse import ArgumentParser
-import pickle
 
 # Local
 from crmprtd.download import retry, ftp_connect
@@ -44,8 +43,8 @@ def download(ftp_server, ftp_dir):
                                                callback)
 
             tempfile.seek(0)
-            pickle.dump('Network module name: wamr', sys.stdout.buffer)
-            pickle.dump(tempfile.readlines(), sys.stdout.buffer)
+            for line in tempfile.readlines():
+                sys.stdout.buffer.write(line.encode('utf-8'))
 
     except Exception:
         log.exception("Unable to process ftp")

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -5,6 +5,7 @@ import sys
 
 from tempfile import SpooledTemporaryFile
 from argparse import ArgumentParser
+import pickle
 
 # Local
 from crmprtd.download import retry, ftp_connect
@@ -43,12 +44,8 @@ def download(ftp_server, ftp_dir):
                                                callback)
 
             tempfile.seek(0)
-
-            # print module name for pipe
-            print("Network module name: wamr")
-            for line in tempfile.readlines():
-                print(line.strip('\n'))
-            sys.stdout.flush()
+            pickle.dump('Network module name: wamr', sys.stdout.buffer)
+            pickle.dump(tempfile.readlines(), sys.stdout.buffer)
 
     except Exception:
         log.exception("Unable to process ftp")

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -15,18 +15,6 @@ from crmprtd import logging_args, setup_logging
 log = logging.getLogger(__name__)
 
 
-def download_args(parser):
-    parser.add_argument('-f', '--ftp_server',
-                        default='ftp.env.gov.bc.ca',
-                        help=('Full hostname of Water and Air Monitoring and '
-                              'Reporting\'s ftp server'))
-    parser.add_argument('-F', '--ftp_dir',
-                        default=('pub/outgoing/AIR/Hourly_Raw_Air_Data/'
-                                 'Meteorological/'),
-                        help='FTP Directory containing WAMR\'s data files')
-    return parser
-
-
 def download(ftp_server, ftp_dir):
     '''Executes the first stage of the data processing pipeline.
 
@@ -90,7 +78,14 @@ class WAMRFTPReader(FTPReader):
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser = download_args(parser)
+    parser.add_argument('-f', '--ftp_server',
+                        default='ftp.env.gov.bc.ca',
+                        help=('Full hostname of Water and Air Monitoring and '
+                              'Reporting\'s ftp server'))
+    parser.add_argument('-F', '--ftp_dir',
+                        default=('pub/outgoing/AIR/Hourly_Raw_Air_Data/'
+                                 'Meteorological/'),
+                        help='FTP Directory containing WAMR\'s data files')
     parser = logging_args(parser)
     args = parser.parse_args()
 

--- a/crmprtd/wamr/normalize.py
+++ b/crmprtd/wamr/normalize.py
@@ -16,6 +16,7 @@ def normalize(file_stream):
     log.info('Starting WAMR data normalization')
 
     for row in itertools.islice(file_stream, 1, None):
+        row = row.decode('utf-8')
         try:
             time, station_id, _, variable_name, \
                 _, _, _, unit, _, _, _, val = row.strip().split(',')

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -6,6 +6,7 @@ import ftplib
 import sys
 from tempfile import SpooledTemporaryFile
 from argparse import ArgumentParser
+import pickle
 
 # Local
 from crmprtd.download import retry, ftp_connect
@@ -37,13 +38,9 @@ def download(username, password, auth_fname, auth_key, ftp_server, ftp_file):
                 ftpreader.connection.retrlines('RETR {}'
                                                .format(filename),
                                                callback)
-
             tempfile.seek(0)
-            # print module name for pipe
-            print("Network module name: wmb")
-            for line in tempfile.readlines():
-                print(line.strip('\n'))
-            sys.stdout.flush()
+            pickle.dump('Network module name: wmb', sys.stdout.buffer)
+            pickle.dump(tempfile.readlines(), sys.stdout.buffer)
 
     except Exception as e:
         log.exception("Unable to process ftp")

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -6,7 +6,6 @@ import ftplib
 import sys
 from tempfile import SpooledTemporaryFile
 from argparse import ArgumentParser
-import pickle
 
 # Local
 from crmprtd.download import retry, ftp_connect
@@ -39,8 +38,8 @@ def download(username, password, auth_fname, auth_key, ftp_server, ftp_file):
                                                .format(filename),
                                                callback)
             tempfile.seek(0)
-            pickle.dump('Network module name: wmb', sys.stdout.buffer)
-            pickle.dump(tempfile.readlines(), sys.stdout.buffer)
+            for line in tempfile.readlines():
+                sys.stdout.buffer.write(line.encode('utf-8'))
 
     except Exception as e:
         log.exception("Unable to process ftp")

--- a/crmprtd/wmb/normalize.py
+++ b/crmprtd/wmb/normalize.py
@@ -19,11 +19,13 @@ def normalize(file_stream):
     # set variable names using first row in file stream
     var_names = []
     for first_row in file_stream:
+        first_row = first_row.decode('utf-8')
         for var in clean_row(first_row):
             var_names.append(var)
         break
 
     for row in file_stream:
+        row = row.decode('utf-8')
         # assign variable name to value
         data = [(var_name, value)
                 for var_name, value in zip(var_names, clean_row(row))]

--- a/scripts/hourly_wmb.py
+++ b/scripts/hourly_wmb.py
@@ -30,8 +30,8 @@ if __name__ == '__main__':
     parser = common_script_arguments(parser)
     parser = common_auth_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
-                  'crmprtd.wmb')
+    setup_logging(args.log_conf, args.log_filename, args.error_email,
+                  args.log_level, 'crmprtd.wmb')
 
     dl_args = ['username', 'password', 'auth_fname', 'auth_key', 'ftp_server',
                'ftp_file']

--- a/scripts/hourly_wmb.py
+++ b/scripts/hourly_wmb.py
@@ -30,8 +30,8 @@ if __name__ == '__main__':
     parser = common_script_arguments(parser)
     parser = common_auth_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log_filename,
-                  args.error_email, args.log_level, 'crmprtd.wmb')
+    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
+                  'crmprtd.wmb')
 
     dl_args = ['username', 'password', 'auth_fname', 'auth_key', 'ftp_server',
                'ftp_file']

--- a/scripts/moti_hourly.py
+++ b/scripts/moti_hourly.py
@@ -25,8 +25,8 @@ if __name__ == '__main__':
     parser = common_script_arguments(parser)
     parser = common_auth_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
-                  'crmprtd.moti')
+    setup_logging(args.log_conf, args.log_filename, args.error_email,
+                  args.log_level, 'crmprtd.moti')
 
     dl_args = ['start_time', 'end_time', 'station_id', 'auth_fname',
                'auth_key', 'username', 'password']

--- a/scripts/moti_hourly.py
+++ b/scripts/moti_hourly.py
@@ -25,8 +25,8 @@ if __name__ == '__main__':
     parser = common_script_arguments(parser)
     parser = common_auth_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log_filename,
-                  args.error_email, args.log_level, 'crmprtd.moti')
+    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
+                  'crmprtd.moti')
 
     dl_args = ['start_time', 'end_time', 'station_id', 'auth_fname',
                'auth_key', 'username', 'password']

--- a/scripts/real_time_ec.py
+++ b/scripts/real_time_ec.py
@@ -31,8 +31,8 @@ if __name__ == '__main__':
                               'this threshold'))
     parser = common_script_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log_filename,
-                  args.error_email, args.log_level, 'crmprtd.ec')
+    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
+                  'crmprtd.ec')
 
     dl_args = ['time', 'frequency', 'province', 'language']
     dl_args = subset_dict(vars(args), dl_args)

--- a/scripts/real_time_ec.py
+++ b/scripts/real_time_ec.py
@@ -31,8 +31,8 @@ if __name__ == '__main__':
                               'this threshold'))
     parser = common_script_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
-                  'crmprtd.ec')
+    setup_logging(args.log_conf, args.log_filename, args.error_email,
+                  args.log_level, 'crmprtd.ec')
 
     dl_args = ['time', 'frequency', 'province', 'language']
     dl_args = subset_dict(vars(args), dl_args)

--- a/scripts/wamr_hourly.py
+++ b/scripts/wamr_hourly.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
     parser = common_script_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
+    setup_logging(args.log_conf, args.log_filename, args.error_email, args.log_level,
                   'crmprtd.wamr')
 
     dl_args = ['ftp_server', 'ftp_dir']

--- a/scripts/wamr_hourly.py
+++ b/scripts/wamr_hourly.py
@@ -2,9 +2,7 @@
 
 '''
 Script to download data from the BC Ministry of Environment Air Quality Branch
-
 Water and Air Monitoring and Reporting? (WAMR)
-
 This is largely lifted and modified from the hourly_wmb.py script
 '''
 
@@ -31,8 +29,8 @@ if __name__ == '__main__':
 
     parser = common_script_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log_filename, args.error_email, args.log_level,
-                  'crmprtd.wamr')
+    setup_logging(args.log_conf, args.log_filename,
+                  args.error_email, args.log_level, 'crmprtd.wamr')
 
     dl_args = ['ftp_server', 'ftp_dir']
     dl_args = subset_dict(vars(args), dl_args)

--- a/scripts/wamr_hourly.py
+++ b/scripts/wamr_hourly.py
@@ -31,8 +31,8 @@ if __name__ == '__main__':
 
     parser = common_script_arguments(parser)
     args = parser.parse_args()
-    setup_logging(args.log_conf, args.log_filename,
-                  args.error_email, args.log_level, 'crmprtd.wamr')
+    setup_logging(args.log_conf, args.log, args.error_email, args.log_level,
+                  'crmprtd.wamr')
 
     dl_args = ['ftp_server', 'ftp_dir']
     dl_args = subset_dict(vars(args), dl_args)

--- a/tests/test_wamr_normalize.py
+++ b/tests/test_wamr_normalize.py
@@ -1,48 +1,48 @@
-from io import StringIO
+from io import BytesIO
 from crmprtd.wamr.normalize import normalize
 
 
 def test_normalize_good_data():
-    lines = '''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
+    lines = b'''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
 2018-07-30 14:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,11.68,% RH,1,n/a,Data Ok,11.7
 2018-07-30 13:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,17.62,% RH,1,n/a,Data Ok,17.6
 2018-07-30 12:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,21.76,% RH,1,n/a,Data Ok,21.8
 2018-07-30 11:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,27.87,% RH,1,n/a,Data Ok,27.9
 2018-07-30 10:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,34.03,% RH,1,n/a,Data Ok,34.0
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     assert len(rows) == 5
     for row in rows:
         assert row.unit == '%'
 
 
 def test_normalize_unpack_error_catch():
-    lines = '''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE, BAD_VAR
+    lines = b'''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE, BAD_VAR
 2018-07-30 14:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,11.68,% RH,1,n/a,Data Ok,11.7,bad_var
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     assert len(rows) == 0
 
 
 def test_normalize_missing_value():
-    lines = '''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
+    lines = b'''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
 2018-07-30 14:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,11.68,% RH,1,n/a,Data Ok,
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     assert len(rows) == 0
 
 
 def test_normalize_bad_value():
-    lines = '''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
+    lines = b'''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
 2018-07-30 14:00,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,11.68,% RH,1,n/a,Data Ok,bad_val
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     assert len(rows) == 0
 
 
 def test_normalize_bad_date():
-    lines = '''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
+    lines = b'''DATE_PST,EMS_ID,STATION_NAME,PARAMETER,AIR_PARAMETER,INSTRUMENT,RAW_VALUE,UNIT,STATUS,AIRCODESTATUS,STATUS_DESCRIPTION,REPORTED_VALUE
 BAD_DATE,0250009,Trail Butler Park Met_60,HUMIDITY,HUMIDITY,HUMIDITY,11.68,% RH,1,n/a,Data Ok,11.7
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     assert len(rows) == 0

--- a/tests/test_wmb_normalize.py
+++ b/tests/test_wmb_normalize.py
@@ -1,4 +1,4 @@
-from io import StringIO
+from io import BytesIO
 from datetime import datetime
 import pytz
 
@@ -6,10 +6,10 @@ from crmprtd.wmb.normalize import normalize
 
 
 def test_normalize_good_data():
-    lines = '''station_code,weather_date,precipitation,temperature,relative_humidity,wind_speed,wind_direction,ffmc,isi,fwi,rn_1_pluvio1,snow_depth,snow_depth_quality,precip_pluvio1_status,precip_pluvio1_total,rn_1_pluvio2,precip_pluvio2_status,precip_pluvio2_total,rn_1_RIT,precip_RIT_Status,precip_RIT_total,precip_rgt,solar_radiation_LICOR,solar_radiation_CM3
+    lines = b'''station_code,weather_date,precipitation,temperature,relative_humidity,wind_speed,wind_direction,ffmc,isi,fwi,rn_1_pluvio1,snow_depth,snow_depth_quality,precip_pluvio1_status,precip_pluvio1_total,rn_1_pluvio2,precip_pluvio2_status,precip_pluvio2_total,rn_1_RIT,precip_RIT_Status,precip_RIT_total,precip_rgt,solar_radiation_LICOR,solar_radiation_CM3
 11,2018052711,.00,14.2,55,10.4,167,81.160995,2.1806495,5.5260615,.00,.00,,,.00,.00,,.00,.00,.00,.00,,.0,
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     tz = pytz.timezone('Canada/Pacific')
     assert len(rows) == 17
     for row in rows:
@@ -22,18 +22,18 @@ def test_normalize_good_data():
 
 
 def test_normalize_bad_date():
-    lines = '''station_code,weather_date,precipitation,temperature,relative_humidity,wind_speed,wind_direction,ffmc,isi,fwi,rn_1_pluvio1,snow_depth,snow_depth_quality,precip_pluvio1_status,precip_pluvio1_total,rn_1_pluvio2,precip_pluvio2_status,precip_pluvio2_total,rn_1_RIT,precip_RIT_Status,precip_RIT_total,precip_rgt,solar_radiation_LICOR,solar_radiation_CM3
+    lines = b'''station_code,weather_date,precipitation,temperature,relative_humidity,wind_speed,wind_direction,ffmc,isi,fwi,rn_1_pluvio1,snow_depth,snow_depth_quality,precip_pluvio1_status,precip_pluvio1_total,rn_1_pluvio2,precip_pluvio2_status,precip_pluvio2_total,rn_1_RIT,precip_RIT_Status,precip_RIT_total,precip_rgt,solar_radiation_LICOR,solar_radiation_CM3
 11,2018052799,.00,14.2,55,10.4,167,81.160995,2.1806495,5.5260615,.00,.00,,,.00,.00,,.00,.00,.00,.00,,.0,
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     assert len(rows) == 0
 
 
 def test_normalize_bad_value():
-    lines = '''station_code,weather_date,precipitation,temperature,relative_humidity,wind_speed,wind_direction,ffmc,isi,fwi,rn_1_pluvio1,snow_depth,snow_depth_quality,precip_pluvio1_status,precip_pluvio1_total,rn_1_pluvio2,precip_pluvio2_status,precip_pluvio2_total,rn_1_RIT,precip_RIT_Status,precip_RIT_total,precip_rgt,solar_radiation_LICOR,solar_radiation_CM3
+    lines = b'''station_code,weather_date,precipitation,temperature,relative_humidity,wind_speed,wind_direction,ffmc,isi,fwi,rn_1_pluvio1,snow_depth,snow_depth_quality,precip_pluvio1_status,precip_pluvio1_total,rn_1_pluvio2,precip_pluvio2_status,precip_pluvio2_total,rn_1_RIT,precip_RIT_Status,precip_RIT_total,precip_rgt,solar_radiation_LICOR,solar_radiation_CM3
 11,2018052711,BAD_VAL,14.2,55,10.4,167,81.160995,2.1806495,5.5260615,.00,.00,,,.00,.00,,.00,.00,.00,.00,,.0,
 ''' # noqa
-    rows = [row for row in normalize(StringIO(lines))]
+    rows = [row for row in normalize(BytesIO(lines))]
     assert len(rows) == 16
     tz = pytz.timezone('Canada/Pacific')
     for row in rows:


### PR DESCRIPTION
The changes in this branch restructure how the pipeline is run internally.  ```download.py``` is now called directly and its output can be piped into either a file, or the new ```process.py``` module.  This module handles the final 3 stages in the pipeline.  

### Notes
- Output is pickled between ```download.py``` and ```process.py```.  The purpose of this was to ensure that the object type was preserved during its trip through stdout.  ```wamr```  and ```wmb``` both output strings, however ```ec``` and ```moti``` output bytes.
- There is some overlapping code that I left in for reference until changes are finished.  This change effectively negates the need for any of the main scripts.