### PR TITLE
Resolves #34

### DIFF
--- a/crmprtd/db_exceptions.py
+++ b/crmprtd/db_exceptions.py
@@ -19,16 +19,3 @@ class InsertionError(Error):
         for k, v in self.data.iteritems():
             s += '{0}: {1}, '.format(k, v)
         return s
-
-
-class UniquenessError(Error):
-    """
-    Exception raised when a tuple already exists in the database
-    """
-
-    def __init__(self, obs_id=None):
-        self.obs_id = obs_id
-
-    def __str__(self):
-        return ('This tuple already exists in database with obs_id '
-                '{0}').format(self.obs_id)

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -4,7 +4,6 @@ import pytest
 import pytz
 
 from pycds import History, Obs
-from crmprtd.db_exceptions import UniquenessError
 from crmprtd.insert import bisect_insert_strategy, split, DBMetrics, chunks, \
     get_sample_indices, obs_exist, contains_all_duplicates, single_insert_obs
 
@@ -130,7 +129,7 @@ def test_contains_all_duplicates_all_dup(test_session):
 
 
 def test_single_insert_obs(test_session):
-    ob = Obs(history_id=20, vars_id=2, time=datetime.now(), datum=10)
+    ob = [Obs(history_id=20, vars_id=2, time=datetime.now(), datum=10)]
     dbm = DBMetrics()
 
     single_insert_obs(test_session, ob, dbm)
@@ -140,9 +139,10 @@ def test_single_insert_obs(test_session):
 
 
 def test_single_insert_obs_not_unique(test_session):
-    ob = Obs(history_id=20, vars_id=2,
-             time=datetime(2012, 9, 24, 6, tzinfo=pytz.utc), datum=10)
+    ob = [Obs(history_id=20, vars_id=2,
+              time=datetime(2012, 9, 24, 6, tzinfo=pytz.utc), datum=10)]
     dbm = DBMetrics()
 
-    with pytest.raises(UniquenessError):
-        single_insert_obs(test_session, ob, dbm)
+    single_insert_obs(test_session, ob, dbm)
+
+    assert dbm.failures == 1


### PR DESCRIPTION
Changed the calling of ```single_insert_obs``` to be similar to ```bisect_insert_strategy```.  Also removed the use of ```UniquenessError`` and instead just increment ```dbm.failures``` and continue.  Tests were updated to reflect these changes.

**Edit**: I referenced the wrong issue in my commit and in the title of this PR, was #33 now #34