### PR TITLE
Post Testing Fixes

### DIFF
--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -10,7 +10,7 @@ pycds.Obs objects. This phase is common to all networks.
 
 import logging
 from sqlalchemy import and_
-from pint import UnitRegistry, UndefinedUnitError
+from pint import UnitRegistry, UndefinedUnitError, DimensionalityError
 
 # local
 from pycds import Obs, History, Network, Variable, Station
@@ -53,6 +53,12 @@ def convert_unit(val, src_unit, dst_unit):
             val = Q_(val, ureg.parse_expression(src_unit))  # src
             val = val.to(dst_unit).magnitude  # dest
         except UndefinedUnitError as e:
+            log.error('Unable to convert units',
+                      extra={'src_unit': src_unit,
+                             'dst_unit': dst_unit,
+                             'exception': e})
+            return None
+        except DimensionalityError as e:
             log.error('Unable to convert units',
                       extra={'src_unit': src_unit,
                              'dst_unit': dst_unit,

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -52,13 +52,7 @@ def convert_unit(val, src_unit, dst_unit):
         try:
             val = Q_(val, ureg.parse_expression(src_unit))  # src
             val = val.to(dst_unit).magnitude  # dest
-        except UndefinedUnitError as e:
-            log.error('Unable to convert units',
-                      extra={'src_unit': src_unit,
-                             'dst_unit': dst_unit,
-                             'exception': e})
-            return None
-        except DimensionalityError as e:
+        except (UndefinedUnitError, DimensionalityError) as e:
             log.error('Unable to convert units',
                       extra={'src_unit': src_unit,
                              'dst_unit': dst_unit,

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -199,8 +199,9 @@ def insert(sesh, observations, sample_size):
     else:
         log.info("Using Chunk + Bisection Strategy")
         with Timer() as tmr:
+            dbm = DBMetrics(0, 0, 0)
             for chunk in chunks(observations):
-                dbm = bisect_insert_strategy(sesh, chunk)
+                dbm += bisect_insert_strategy(sesh, chunk)
 
     log.info('Data insertion complete')
     return {'successes': dbm.successes,

--- a/crmprtd/wamr/normalize.py
+++ b/crmprtd/wamr/normalize.py
@@ -46,6 +46,12 @@ def normalize(file_stream):
 
         if unit == '% RH':
             unit = re.sub('% RH', '%', unit)
+        elif unit == '\u00b0C':
+            unit = re.sub('\u00b0C', 'celsius', unit)
+        elif unit == 'mb':
+            unit = re.sub('mb', 'millibar', unit)
+        elif unit == 'Deg':
+            unit = re.sub('Deg', 'degree', unit)
 
         yield Row(time=dt,
                   val=value,

--- a/crmprtd/wamr/normalize.py
+++ b/crmprtd/wamr/normalize.py
@@ -44,14 +44,15 @@ def normalize(file_stream):
                       extra={'time': time})
             continue
 
-        if unit == '% RH':
-            unit = re.sub('% RH', '%', unit)
-        elif unit == '\u00b0C':
-            unit = re.sub('\u00b0C', 'celsius', unit)
-        elif unit == 'mb':
-            unit = re.sub('mb', 'millibar', unit)
-        elif unit == 'Deg':
-            unit = re.sub('Deg', 'degree', unit)
+        substitutions = [
+            ('% RH', '%'),
+            ('\u00b0C', 'celsius'),
+            ('mb', 'millibar'),
+            ('Deg', 'degree')
+        ]
+        for src, dest in substitutions:
+            if unit == src:
+                unit = re.sub(src, dest, unit)
 
         yield Row(time=dt,
                   val=value,


### PR DESCRIPTION
This branch contains some smalls changes to several bits of code.  A full test was done to ensure that the code can handle all stages of the pipeline and successfully insert into a database.  The changes here also resolve #39.  Below are the steps I took to perform the tests.

# Setting up the database
In order to test the data pipeline we need to create a local database which the scripts can insert to.  Here are the steps taken:

 1. Open terminal and create a database: `$ createdb {dbname}`
 2. Enter the database: `$ psql`
 3. Create a schema: `=# CREATE SCHEMA crmp;`
 4. Add postgis: `=# CREATE EXTENSION postgis;`
 5. Exit db: `CTRL+D`
 6. Navigate to: `pycds/scripts/`
 7. Create the crmp database: `$ python mktestdb.py -t postgres://{username}@localhost/{dbname}`

# Setting up the networks
Now each individual network needs to be setup in order for the scripts to be able to insert.  This process will mostly be adding the networks to the table and the variables each network tracks.

## EC
Environment Canada

### Add Network
 - `=# INSERT INTO crmp.meta_network (network_name) VALUES ('EC_raw');` 

### Add Variables
 - `=# INSERT INTO crmp.meta_vars (network_id, unit, standard_name, cell_method, long_description, net_var_name, display_name, short_name) VALUES (1, 'Celsius','air_temperature','time: point','Hourly air temperature','air_temperature','Temperature (Point)','air_temperature_point'), (1,'km/h','wind_speed_of_gust','time: maximum','Maximum speed of wind gust','wind_gust_speed','Wind Gust (Max.)','wind_speed_of_gust_maximum'), (1,'Celsius','air_temperature','time: maximum','Maximum daily air temperature','air_temperature_yesterday_high','Temperature (Max.)','air_temperature_maximum'), (1,'Celsius','air_temperature','time: minimum','Minimum daily air temperature','air_temperature_yesterday_low','Temperature (Min.)','air_temperature_minimum'), (1,'mm','lwe_thickness_of_precipitation_amount','time: sum','Daily precipitation amount','total_precipitation','Precipitation Amount','lwe_thickness_of_precipitation_amount_sum'), (1,'mm','thickness_of_rainfall_amount','time: sum','Daily rainfall amount','total_rain','Rainfall Amount','thickness_of_rainfall_amount_sum'), (1,'cm','thickness_of_snowfall_amount','time: sum','Daily snowfall','snow_amount','Snowfall Amount','thickness_of_snowfall_amount_sum'), (1,'kPa','mean_sea_level','time: point','Hourly mean sea level','mean_sea_level','Mean Sea Level','mean_sea_level_point'), (1,'km/h','wind_speed','time: point','Instantaneous wind speed','wind_speed','Wind Speed (Point)','wind_speed_point'), (1,'Celsius','dew_point_temperature','time: point','Dew point','dew_point','Dew Point Temperature (Point)','dew_point_temperature_point'), (1,'percent','relative_humidity','time: point','Relative humidity','relative_humidity','Relative Humidity (Point)','relative_humidity_point'), (1,'degree','wind_from_direction','time: mean','Wind direction octants','wind_direction','Wind Direction (Mean)','wind_from_direction_mean'), (1,'percent','cloud_area_fraction','time: point','Total cloud cover','total_cloud_cover','Cloud Cover Fraction','cloud_area_fraction_point'), (1,'kPa s-1','tendency_of_air_pressure','time: sum','Air pressure tendency','tendency_amount','Air Pressure Tendency','tendency_of_air_pressure_sum'), (1,'celsius','air_temperature','t: maximum within days t: mean within months t: mean over years','Climatological mean of monthly mean maximum daily temperature','Tx_Climatology','Temperature Climatology (Max.)','air_temperaturet: maximum within days t: mean within months t: mean over years'), (1,'celsius','air_temperature','t: minimum within days t: mean within months t: mean over years','Climatological mean of monthly mean minimum daily temperature','Tn_Climatology','Temperature Climatology (Min.)','air_temperaturet: minimum within days t: mean within months t: mean over years'), (1,'celsius','air_temperature','t: mean within days t: mean within months t: mean over years','Climatological mean of monthly mean of mean daily temperature','T_mean_Climatology','Temperature Climatology (Mean)','air_temperaturet: mean within days t: mean within months t: mean over years'), (1,'mm','lwe_thickness_of_precipitation_amount','t: sum within months t: mean over years','Climatological mean of monthly total precipitation','Precip_Climatology','Precipitation Climatology','lwe_thickness_of_precipitation_amountt: sum within months t: mean over years');`
 - The result here should say `INSERT 0 18`

## MoTIe
Ministry of Transportation

### Add Network
 - `=# INSERT INTO crmp.meta_network (network_name) VALUES ('MoTIe');`


### Add Variables
 - `=# INSERT INTO crmp.meta_vars (network_id, unit, standard_name, cell_method, long_description, net_var_name, display_name, short_name) VALUES (2,'celsius','air_temperature','time: maximum','','MAXIMUM_AIR_TEMPERATURE','Temperature (Max.)','air_temperature_maximum'), (2,'celsius','air_temperature','time: point','','CURRENT_AIR_TEMPERATURE1','Temperature (Point)','air_temperature_point'), (2,'celsius','air_temperature','time: minimum','','MINIMUM_AIR_TEMPERATURE','Temperature (Min.)','air_temperature_minimum'), (2,'celsius','air_temperature','time: point','','CURRENT_AIR_TEMPERATURE2','Temperature (Point)','air_temperature_point'), (2,'%','relative_humidity','time: mean','','RELATIVE_HUMIDITY1','Relative Humidity (Mean)','relative_humidity_mean'), (2,'celsius','dew_point_temperature','time: mean','','DEW_POINT','Dew Point Temperature (Mean)','dew_point_temperature_mean'), (2,'millibar','air_pressure','time: point','','ATMOSPHERIC_PRESSURE','Air Pressure (Point)','air_pressure_point'), (2,'mm','lwe_thickness_of_precipitation_amount','t: sum over days interval: irregular','','PRECIPITATION_GAUGE_TOTAL','Precipitation (Cumulative)','lwe_thickness_of_precipitation_sum'), (2,'mm','lwe_thickness_of_precipitation_amount','time: sum','','PRECIPITATION_NEW','Precipitation Amount','lwe_thickness_of_precipitation_amount_sum'), (2,'mm','lwe_thickness_of_precipitation_amount','t: sum within days interval: daily','','HOURLY_PRECIPITATION','Precipitation Amount','lwe_thickness_of_precipitation_amount_sum'), (2,'1','','time: mean','','PRECIP_DETECTOR_RATIO','Rainfall Amount',''), (2,'','wind_speed','time: point','','ACTUAL_WIND_SPEED','Wind Speed (Point)','wind_speed_point'), (2,'degrees','wind_from_direction','time: point','','ACTUAL_WIND_DIRECTION','Wind Direction (Point)','wind_from_direction_point'), (2,'km h-1','wind_speed','time: mean','','MEASURED_WIND_SPEED1','Wind Speed (Mean)','wind_speed_mean'), (2,'degrees','wind_from_direction','time: mean','','MEASURED_WIND_DIRECTION1','Wind Direction (Mean)','wind_from_direction_mean'), (2,'degrees','wind_from_direction','time: standard_deviation','','WIND_DIRECTION_STD_DEVIATION1','Wind Direction (Std Dev)','wind_from_direction_standard_deviation'), (2,'km h-1','wind_speed','time: maximum','','MAXIMUM_MEASURED_WIND_SPEED1','Wind Speed (Max.)','wind_speed_maximum'), (2,'cm','surface_snow_thickness','time: point','','HEIGHT_OF_SNOW','Surface Snow Depth (Point)','surface_snow_thickness_point'), (2,'cm','thickness_of_snowfall_amount','time: sum','','STANDARD_SNOW','Snowfall Amount','thickness_of_snowfall_amount_sum'), (2,'celsius','air_temperature','t: maximum within days t: mean within months t: mean over years','Climatological mean of monthly mean maximum daily temperature','Tx_Climatology','Temperature Climatology (Max.)','air_temperaturet: maximum within days t: mean within months t: mean over years'), (2,'celsius','air_temperature','t: minimum within days t: mean within months t: mean over years','Climatological mean of monthly mean minimum daily temperature','Tn_Climatology','Temperature Climatology (Min.)','air_temperaturet: minimum within days t: mean within months t: mean over years'), (2,'celsius','air_temperature','t: mean within days t: mean within months t: mean over years','Climatological mean of monthly mean of mean daily temperature','T_mean_Climatology','Temperature Climatology (Mean)','air_temperaturet: mean within days t: mean within months t: mean over years'), (2,'mm','lwe_thickness_of_precipitation_amount','t: sum within months t: mean over years','Climatological mean of monthly total precipitation','Precip_Climatology','Precipitation Climatology','lwe_thickness_of_precipitation_amountt: sum within months t: mean over years');`
 - The result should say `INSERT 0 23`

## WAMR
Ministry of Environment

### Add Network
 - `=# INSERT INTO crmp.meta_network (network_name) VALUES ('ENV-AQN');`

### Add Variables
 - `=# INSERT INTO crmp.meta_vars (network_id, unit, standard_name, cell_method, long_description, net_var_name, display_name, short_name) VALUES (3,'celsius','air_temperature','time: mean','Present temperature','TEMP_MEAN','Temperature (Mean)','air_temperature_mean'), (3,'mm','lwe_thickness_of_precipitation_amount','time: sum','Hourly precipitation','PRECIP_TOTAL','Precipitation Amount','lwe_thickness_of_precipitation_amount_sum'), (3,'%','relative_humidity','time: point','Relative humidity','HUMIDITY','Relative Humidity (Point)','relative_humidity_point'), (3,'millibar','air_pressure','time: point','Atmospheric pressure','BAR_PRESS','Air Pressure (Point)','air_pressure_point'), (3,'degree','wind_from_direction','time: point','','WDIR_VECT','Wind Direction (Point)','wind_from_direction_point'), (3,'','wind_speed','time: point','','WSPD_SCLR','Wind Speed (Point)','wind_speed_point'), (3,'celsius','air_temperature','t: maximum within days t: mean within months t: mean over years','Climatological mean of monthly mean maximum daily temperature','Tx_Climatology','Temperature Climatology (Max.)','air_temperaturet: maximum within days t: mean within months t: mean over years'), (3,'celsius','air_temperature','t: minimum within days t: mean within months t: mean over years','Climatological mean of monthly mean minimum daily temperature','Tn_Climatology','Temperature Climatology (Min.)','air_temperaturet: minimum within days t: mean within months t: mean over years'), (3,'celsius','air_temperature','t: mean within days t: mean within months t: mean over years','Climatological mean of monthly mean of mean daily temperature','T_mean_Climatology','Temperature Climatology (Mean)','air_temperaturet: mean within days t: mean within months t: mean over years'), (3,'mm','lwe_thickness_of_precipitation_amount','t: sum within months t: mean over years','Climatological mean of monthly total precipitation','Precip_Climatology','Precipitation Climatology','lwe_thickness_of_precipitation_amountt: sum within months t: mean over years');`
 - The result should say `INSERT 0 10`

## WMB
Wild Fire Management Branch

## Add Network
 - `=# INSERT INTO crmp.meta_network (network_name) VALUES ('FLNRO-WMB');`

## Add Variables
 - `=# INSERT INTO crmp.meta_vars (network_id, unit, standard_name, cell_method, long_description, net_var_name, display_name, short_name) VALUES (4,'mm','lwe_thickness_of_precipitation_amount','time: sum','depth of water-equivalent rain','precipitation','Precipitation Amount','lwe_thickness_of_precipitation_amount_sum'), (4,'celsius','air_temperature','time: point','','temperature','Temperature (Point)','air_temperature_point'), (4,'%','relative_humidity','time: mean','','relative_humidity','Relative Humidity (Mean)','relative_humidity_mean'), (4,'m s-1','wind_speed','time: mean','','wind_speed','Wind Speed (Mean)','wind_speed_mean'), (4,'degree','wind_from_direction','time: mean','','wind_direction','Wind Direction (Mean)','wind_from_direction_mean'), (4,'celsius','air_temperature','t: maximum within days t: mean within months t: mean over years','Climatological mean of monthly mean maximum daily temperature','Tx_Climatology','Temperature Climatology (Max.)','air_temperaturet: maximum within days t: mean within months t: mean over years'), (4,'celsius','air_temperature','t: minimum within days t: mean within months t: mean over years','Climatological mean of monthly mean minimum daily temperature','Tn_Climatology','Temperature Climatology (Min.)','air_temperaturet: minimum within days t: mean within months t: mean over years'), (4,'celsius','air_temperature','t: mean within days t: mean within months t: mean over years','Climatological mean of monthly mean of mean daily temperature','T_mean_Climatology','Temperature Climatology (Mean)','air_temperaturet: mean within days t: mean within months t: mean over years'), (4,'mm','lwe_thickness_of_precipitation_amount','t: sum within months t: mean over years','Climatological mean of monthly total precipitation','Precip_Climatology','Precipitation Climatology','lwe_thickness_of_precipitation_amountt: sum within months t: mean over years');`
 - The result should say `INSERT 0 9`

# Running the scripts
The scripts run in the tests will first be saved to a file to make it easier to compare the results.  Some setup before continuing:
 1. Navigate to `Desktop/`
 2. `$ mkdir devdb_files`
 3. `$ cd devdb_files`
 4. `$ touch ec_save_file moti_save_file wamr_save_file wmb_save_file`
 5. Navigate to `crmprtd/crmprtd`

## EC
 1. To retrieve the downloaded data: `$ python ec/download.py -p BC -F hourly --log_level=INFO --log_filename ~/Desktop/devdb_files/ec.log > ~/Desktop/devdb_files/ec_save_file`
 2. Use the data in the data pipeline: `$ python process.py -N ec -c 'postgres://{username}@localhost/{dbname}' --log_filename ~/Desktop/devdb_files/ec.log < ~/Desktop/devdb_files/ec_save_file`

Here is some of the output from this particular run:
`{"asctime": "2018-08-24 13:30:28,805", "levelname": "INFO", "name": "crmprtd.insert", "message": "Using Chunk + Bisection Strategy"}`
`{"asctime": "2018-08-24 13:30:29,042", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 512}`
`{"asctime": "2018-08-24 13:30:29,211", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 256}`
`{"asctime": "2018-08-24 13:30:29,261", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 64}`
`{"asctime": "2018-08-24 13:30:29,288", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 32}`
`{"asctime": "2018-08-24 13:30:29,303", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 16}`
`{"asctime": "2018-08-24 13:30:29,314", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 4}`
`{"asctime": "2018-08-24 13:30:29,327", "levelname": "INFO", "name": "crmprtd.insert", "message": "Data insertion complete"}`
`{"asctime": "2018-08-24 13:30:29,328", "levelname": "INFO", "name": "crmprtd", "message": "Data insertion results", "results": {"skips": 0, "failures": 0, "successes": 885, "insertions_per_sec": 1696.13}}`

Check with database:
`=# select count(*) from crmp.obs_raw;`
` count ` 
`-------`
`   885 `
`(1 row)`


## MOTI
 1. To retrieve the download data: `$ python moti/download.py --auth_fname ~/.rtd_auth.yaml --auth_key=moti -l ~/Desktop/devdb_files/moti.log --log_level=INFO > ~/Desktop/devdb_files/moti_save_file`
 2. Use the data in the data pipeline: `$ python process.py -N moti -c 'postgres://{username}@localhost/{dbname}' -l ~/Desktop/devdb_files/moti.log --log_level=INFO < ~/Desktop/devdb_files/moti_save_file`


Here is some of the output from this particular run:
`{"asctime": "2018-08-24 13:49:25,288", "levelname": "INFO", "name": "crmprtd.insert", "message": "Using Chunk + Bisection Strategy"}`
`{"asctime": "2018-08-24 13:49:25,469", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 512}`
`{"asctime": "2018-08-24 13:49:25,543", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 128}`
`{"asctime": "2018-08-24 13:49:25,566", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 32}`
`{"asctime": "2018-08-24 13:49:25,576", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 8}`
`{"asctime": "2018-08-24 13:49:25,583", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 2}`
`{"asctime": "2018-08-24 13:49:25,588", "levelname": "INFO", "name": "crmprtd.insert", "message": "Data insertion complete"}`
`{"asctime": "2018-08-24 13:49:25,588", "levelname": "INFO", "name": "crmprtd", "message": "Data insertion results", "results": {"successes": 682, "skips": 0, "insertions_per_sec": 2275.91, "failures": 0}}`

Check with the database:
`=# select count(*) from crmp.obs_raw;`
` count `
`-------`
`   682 `
`(1 row)`


## WAMR
 1. To retrieve the downloaded data: `$ python wamr/download.py --log_level INFO --log_filename ~/Desktop/devdb_files/wamr.log > ~/Desktop/devdb_files/wamr_save_file`
 2. Use the data in the data pipeline: `$ python process.py -N wamr -c 'postgres://{username}@localhost/{dbname}' --log_level DEBUG --log_filename ~/Desktop/devdb_files/wamr.log < ~/Desktop/devdb_files/wamr_save_file`

Here is some of the output from this particular run:
`{"asctime": "2018-08-27 11:13:53,082", "levelname": "INFO", "name": "crmprtd.insert", "message": "Using Chunk + Bisection Strategy"}`
`{"asctime": "2018-08-27 11:15:09,561", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 131072}`
`{"asctime": "2018-08-27 11:15:19,975", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 16384}`
`{"asctime": "2018-08-27 11:15:23,074", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 4096}`
`{"asctime": "2018-08-27 11:15:23,923", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 64}`
`{"asctime": "2018-08-27 11:15:24,722", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 32}`
`{"asctime": "2018-08-27 11:15:25,504", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 8}`
`{"asctime": "2018-08-27 11:15:26,290", "levelname": "INFO", "name": "crmprtd.insert", "message": "Successfully inserted observations", "num_obs": 2}`
`{"asctime": "2018-08-27 11:15:27,832", "levelname": "INFO", "name": "crmprtd.insert", "message": "Data insertion complete"}`
`{"asctime": "2018-08-27 11:15:27,835", "levelname": "INFO", "name": "crmprtd", "message": "Data insertion results", "results": {"failures": 0, "insertions_per_sec": 1600.64, "skips": 0, "successes": 151659}}`

check with the database:
`=# select count(*) from crmp.obs_raw;`
` count  `
`--------`
` 151659 `
`(1 row)`
