### PR TITLE
Add diagnostic (no commit) mode to process script

### DIFF
--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -151,6 +151,7 @@ def setup_logging(log_conf, log_filename, error_email, log_level, name):
 
     if log_level:
         base_config['root']['level'] = log_level
+        base_config['loggers']['crmprtd']['level'] = log_level
 
     logging.config.dictConfig(base_config)
 

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -153,16 +153,20 @@ def get_variable(sesh, network_name, variable_name):
 
 
 def get_history(sesh, network_name, native_id, lat, lon):
+    log.debug("Searching for native_id = %s", native_id)
     histories = sesh.query(History).join(Station).join(Network).filter(and_(
         Network.name == network_name,
         Station.native_id == native_id))
 
     if histories.count() == 0:
+        log.debug("Cound not find native_id %s", native_id)
         return create_station_and_history_entry(sesh, network_name, native_id,
                                                 lat, lon)
     elif histories.count() == 1:
+        log.debug("Found exactly one matching history_id")
         return histories.one_or_none()
     elif histories.count() >= 2:
+        log.debug("Found multiple history entries. Searching for match.")
         return match_station(sesh, network_name, native_id, lat, lon,
                              histories)
 
@@ -207,9 +211,8 @@ def align(sesh, obs_tuple):
 
     # Necessary attributes for Obs object
     if not variable:
-        log.debug('Variable is not tracked by crmp',
-                  extra={'variable': obs_tuple.variable_name,
-                         'network_name': obs_tuple.network_name})
+        log.debug('Variable "%s" from network "%s" is not tracked by crmp',
+                  obs_tuple.variable_name, obs_tuple.network_name)
         return None
 
     datum = unit_check(obs_tuple.val, obs_tuple.unit, variable.unit)


### PR DESCRIPTION
This script adds a "diagnostic mode" to the process script. The mode was previously unused, so these commits add the code required to skip database modifications.

Basically when in use it disables the creation of any stations and skips over the creation of any new observations (instead logging them at level INFO).