### PR TITLE
Ignore MSNG values

### DIFF
--- a/crmprtd/swob_ml.py
+++ b/crmprtd/swob_ml.py
@@ -60,6 +60,7 @@ def normalize_xml(file_stream, network_name,
                 val = ele.get('value')
                 # Ignore missing values. We don't record them.
                 if val == 'MSNG':
+                    log.debug('Ignoring missing obs with value \'MSNG\'')
                     continue
                 val = float(val)
             # This shouldn't ever be empty based on our xpath for selecting

--- a/crmprtd/swob_ml.py
+++ b/crmprtd/swob_ml.py
@@ -57,9 +57,13 @@ def normalize_xml(file_stream, network_name,
                         "{}[@name='{}']".format(
                             no_ns_element('element'), var
                         ), namespaces=ns)[0]
-                val = float(ele.get('value'))
-            # This shouldn't every be empty based on our xpath for selecting
-            # elements, however I think that it _could_ be non-numeric and
+                val = ele.get('value')
+                # Ignore missing values. We don't record them.
+                if val == 'MSNG':
+                    continue
+                val = float(val)
+            # This shouldn't ever be empty based on our xpath for selecting
+            # elements, however it could be non-numeric and
             # still be valid XML
             except ValueError as e:
                 log.error('Unable to convert value',

--- a/tests/swob_data.py
+++ b/tests/swob_data.py
@@ -488,3 +488,74 @@ multi_xml_download = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
     </om:Observation>
   </om:member>
 </om:ObservationCollection>'''.encode('utf-8').splitlines()
+
+MSNG_values_xml = '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<om:ObservationCollection xmlns:om="http://www.opengis.net/om/1.0" xmlns="http://dms.ec.gc.ca/schema/point-observation/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <om:member>
+    <om:Observation>
+      <om:metadata>
+        <set>
+          <general>
+            <author build="build.24" name="MSC-DMS-PG-SWOB" version="3.0"/>
+            <dataset name="partners/observation/atmospheric/surface_weather/bc_tran-1.0-csv"/>
+            <phase name="product_generic_swob-xml-2.0"/>
+            <id xlink:href="/data/partners/observation/atmospheric/surface_weather/bc_tran-1.0-csv/product_generic_swob-xml-2.0/20200103000000000/bc_tran_11091/11091/orig/data_60"/>
+            <parent xlink:href="/data/partners/observation/atmospheric/surface_weather/bc_tran-1.0-csv/decoded_enhanced-xml-2.0/20200103000000000/bc_tran_11091/11091/orig/data_60"/>
+          </general>
+          <identification-elements>
+            <element name="data_pvdr" uom="unitless" value="BC-TRAN"/>
+            <element name="data_attrib_not" uom="unitless" value="Observational data provided by the Government of British Columbia: Ministry of Transportation and Infrastructure (BC-TRAN). All rights reserved. | Données d’observation fournies par le Gouvernement de la Colombie-Britannique: Ministère des Transports et de l’Infrastructure (CB-TRAN). Tous droits réservés."/>
+            <element name="stn_id" uom="unitless" value="11091"/>
+            <element name="stn_nam" uom="unitless" value="BRANDWYINE"/>
+            <element name="stn_shrt_nam" uom="unitless" value="BRNWRW"/>
+            <element name="lat" uom="°" value="50.054170"/>
+            <element name="long" uom="°" value="-123.118060"/>
+            <element name="stn_elev" uom="m" value="496.000"/>
+            <element name="msc_id" uom="unitless" value="BC_TRAN_11091"/>
+            <element name="date_tm" uom="datetime" value="2020-01-03T00:00:00.000Z"/>
+            <element name="last_reset_date_tm" uom="datetime" value="2020-01-02T14:00:00.000Z"/>
+          </identification-elements>
+        </set>
+      </om:metadata>
+      <om:samplingTime>
+        <gml:TimeInstant>
+          <gml:timePosition>2020-01-03T00:00:00.000Z</gml:timePosition>
+        </gml:TimeInstant>
+      </om:samplingTime>
+      <om:resultTime>
+        <gml:TimeInstant>
+          <gml:timePosition>2020-01-03T00:10:34.920Z</gml:timePosition>
+        </gml:TimeInstant>
+      </om:resultTime>
+      <om:procedure xlink:href="/metadata/partners/mr/sfc_wx_cfg/bc_tran/instance-xml-2.0/bc_tran_11091/11091?version=1.2"/>
+      <om:observedProperty gml:remoteSchema="/schema/point-observation/2.0.xsd"/>
+      <om:featureOfInterest>
+        <gml:FeatureCollection>
+          <gml:location>
+            <gml:Point>
+              <gml:pos>50.05417 -123.11806</gml:pos>
+            </gml:Point>
+          </gml:location>
+        </gml:FeatureCollection>
+      </om:featureOfInterest>
+      <om:result>
+        <elements>
+          <element name="pcpn_amt_pst3hrs" uom="mm" value="MSNG">
+            <qualifier code-src="std_code_src" code-type="data_flags" name="data_flag" uom="code" value="4"/>
+          </element>
+          <element name="pcpn_amt_pst6hrs" uom="mm" value="MSNG">
+            <qualifier code-src="std_code_src" code-type="data_flags" name="data_flag" uom="code" value="4"/>
+          </element>
+          <element name="pcpn_amt_pst24hrs" uom="mm" value="MSNG">
+            <qualifier code-src="std_code_src" code-type="data_flags" name="data_flag" uom="code" value="4"/>
+          </element>
+          <element name="mslp" uom="hPa" value="1012.7">
+            <qualifier code-src="std_code_src" code-type="data_flags" name="data_flag" uom="code" value="1"/>
+          </element>
+        </elements>
+      </om:result>
+    </om:Observation>
+  </om:member>
+</om:ObservationCollection>
+
+'''.encode('utf-8').splitlines()

--- a/tests/test_ec_swob_normalize.py
+++ b/tests/test_ec_swob_normalize.py
@@ -2,7 +2,7 @@ from collections import Iterable
 
 import pytest
 
-from .swob_data import multi_xml_download
+from .swob_data import multi_xml_download, MSNG_values_xml
 from crmprtd.bc_env_aq.normalize import normalize as norm_aq
 from crmprtd.bc_env_snow.normalize import normalize as norm_snow
 from crmprtd.bc_forestry.normalize import normalize as norm_forest
@@ -20,3 +20,13 @@ def test_normalize(function):
     assert isinstance(iterator, Iterable)
     for x in iterator:
         assert True
+
+
+def test_normalize_missing_values():
+    # The test data here has 3 missing values that shouldn't generate anything
+    # and 1 actual value that should
+    iterator = norm_tran(MSNG_values_xml)
+    assert isinstance(iterator, Iterable)
+    assert next(iterator)
+    with pytest.raises(StopIteration):
+        next(iterator)

--- a/tests/test_ec_swob_normalize.py
+++ b/tests/test_ec_swob_normalize.py
@@ -1,3 +1,5 @@
+import re
+import logging
 from collections import Iterable
 
 import pytest
@@ -22,11 +24,14 @@ def test_normalize(function):
         assert True
 
 
-def test_normalize_missing_values():
+def test_normalize_missing_values(caplog):
     # The test data here has 3 missing values that shouldn't generate anything
     # and 1 actual value that should
     iterator = norm_tran(MSNG_values_xml)
     assert isinstance(iterator, Iterable)
     assert next(iterator)
-    with pytest.raises(StopIteration):
+    with pytest.raises(StopIteration), caplog.at_level(
+            logging.DEBUG, logger="crmprtd.swob_ml"):
         next(iterator)
+        # There should be 3 DEBUG log messages about skipping a MSNG value
+        assert re.search(r'(Ignoring.*){3}', caplog.text)


### PR DESCRIPTION
We're seeing upwards of 100,000 log entries under level `ERROR` per day that are simply "observations" with value "MSNG" i.e. missing. We don't record missing values. If there's no data, we don't record it.

This patch demotes these events to just be ignored, or optionally logged at `DEBUG` level.
