### PR TITLE
Adds infilling script to repo

### DIFF
--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -1,0 +1,196 @@
+'''Infill crmprtd data for *all* networks for some time range
+'''
+
+import datetime
+from argparse import ArgumentParser
+from warnings import warn
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from pycds import Station, Network
+
+from crmprtd import logging_args, setup_logging
+from crmprtd.ec.download import download as ec_download
+from crmprtd.moti.download import download as moti_download
+from crmprtd.wmb.download import download as wmb_download
+from crmprtd.wamr.download import download as wamr_download
+from crmprtd.ec_swob.download import download as swob_download
+
+
+def main():
+    desc = globals()['__doc__']
+    parser = ArgumentParser(description=desc)
+    parser.add_argument('-S', '--start_time',
+                        help=("Alternate time to use for downloading "
+                              "(interpreted with "
+                              "strptime(format='Y/m/d H:M:S')."))
+    parser.add_argument('-E', '--end_time',
+                        help=("Alternate time to use for downloading "
+                              "(interpreted with "
+                              "strptime(format='Y/m/d H:M:S')."))
+    parser.add_argument('-a', '--auth_fname',
+                        help="Yaml file with plaintext usernames/passwords")
+    parser.add_argument('-c', '--connection_string',
+                        help='PostgreSQL connection string',
+                        required=True)
+
+
+    parser = logging_args(parser)
+    args = parser.parse_args()
+
+    setup_logging(args.log_conf, args.log_filename, args.error_email,
+                  args.log_level, 'infill_all')
+    s = datetime.datetime.strptime(args.start_time, '%Y/%m/%d %H:%M:%S')
+    e = datetime.datetime.strptime(args.end_time, '%Y/%m/%d %H:%M:%S')
+    infill(s, e, args.auth_fname)
+
+
+def infill(start_time, end_time, auth_fname, connection_string):
+
+    weekly_ranges = list(datetime_range(start_time, end_time, resolution='week'))
+    daily_ranges = list(datetime_range(start_time, end_time, resolution='day'))
+    hourly_ranges = list(datetime_range(start_time, end_time, resolution='hour'))
+
+    # Unfortunately most of the download functions only accepts a time
+    # *string* :(
+    time_fmt = '%Y/%m/%d %H:%M:%S'
+
+    process = ["crmprtd_process", f"-c {connection_string}"]
+    
+    # EC
+    for freq, times in zip(('daily', 'hourly'), (daily_ranges, hourly_ranges)):
+        for province in ('YT', 'BC'):
+            for time in times:
+                proc = ["download_ec", f"-p {province}", f"-F {freq}", "-g e",
+                        f"-t {time.strftime(time_fmt)}"]
+                print(proc.join(' '))
+                dl_proc = run(proc, capture_output=True)
+                process_proc = run(process + ["-N ec"], stdin=dl_proc.stdout)
+
+    # MOTI
+    # Query all of the stations
+    stations = get_moti_stations(connection_string)
+    # Divide range into 7 day intervals
+    for interval_start, interval_end in zip(
+            weekly_ranges[:-1], weekly_ranges[1:]):
+        for station in stations:
+            start = interval_start.strftime(time_fmt)
+            end = interval_end.strftime(time_fmt)
+            print(f"moti_download('', '', {auth_fname}, 'moti',"
+                          f"{start}, {end}, {station})")
+
+    warning_msg = {
+        "disjoint":
+                "{} cannot be infilled since the period of infilling is "
+                "outside the currently offered data (the previous {}).",
+        "not_contained":
+                "{} infilling may miss some data since the requested infilling"
+                " period is larger than the currently offered period of record "
+                "(the previous {})."
+    }
+    now = datetime.datetime.now()
+
+    # WAMR
+    # Check that the interval overlaps with the last month
+    last_month = (now - datetime.timedelta(days=30), now)
+    # Warn if not
+    if not interval_overlaps((start_time, end_time), last_month):
+        warn(warning_msg['disjoin'].format("WAMR", "one month"))
+    else:
+        if not interval_contains((start_time, end_time), last_month):
+            warn(warning_msg['not_contained'].format("WAMR", "one_month"))
+        print("wamr_download('ftp.env.gov.bc.ca', 'pub/outgoing/AIR/'"
+                      "'Hourly_Raw_Air_Data/Meteorological/')")
+        
+    # WMB
+    yesterday = (now - datetime.timedelta(days=1), now)
+    # Check that the interval overlaps with the last day
+    # Warn if not
+    if not interval_overlaps((start_time, end_time), yesterday):
+        warn(warning_msg['disjoint'].format("WMB", "day"))
+    else:
+        if not interval_contains((start_time, end_time), yesterday):
+            warn(warning_msg['not_contained'].format("WMB", "day"))
+        # Run it
+        print(f"wmb_download("
+            f"'', '', {auth_fname}, 'wmb',"
+            f"'BCFireweatherFTPp1.nrs.gov.bc.ca',"
+            f"'HourlyWeatherAllFields_WA.txt'"
+              f")")
+
+    # EC_SWOB
+    for partner in ('bc_env_snow', 'bc_tran', 'bc_forestry'):
+        print(partner)
+        for hour in hourly_ranges:
+            print(hour)
+            print(f"swob_download("
+                f"f'https://dd.weather.gc.ca/observations/swob-ml/partners/{partner}/',"
+                f"{hour.strftime(time_fmt)}"
+                  f")")
+
+
+def round_datetime(d, resolution='hour', direction='down'):
+    d = d.replace(minute=0, second=0, microsecond=0)
+    if resolution == 'day':
+        d = d.replace(hour=0)
+    elif resolution == 'hour':
+        pass
+    else:
+        raise ValueError(f"resolution parameter can only be 'hour' or 'day' "
+                         "not '{resolution}'")
+    if direction == 'up':
+        kwargs = {resolution + 's': 1}
+        delta = datetime.timedelta(**kwargs)
+    elif direction == 'down':
+        delta = datetime.timedelta()
+    else:
+        raise ValueError(f"direction parameter can only be 'down' or 'up' "
+                         "not '{direction}'")
+
+    return d + delta
+
+
+def datetime_range(start, end, resolution='hour'):
+    if resolution not in ('hour', 'day', 'week'):
+        raise ValueError
+    kwargs = {resolution + 's': 1}
+    step = datetime.timedelta(**kwargs)
+    
+    # Don't round down to the week... just the day and end at the actual end
+    if resolution == 'week':
+        start = round_datetime(start, 'day', direction='down')
+        # Otherwise, make a rounded timeseries to the day or hour
+    else:
+        start = round_datetime(start, resolution, direction='down')
+        end = round_datetime(end, resolution, direction='up')
+
+    i = 0
+    t = start
+    while t < end:
+        yield t
+        t += step
+    yield end
+
+
+def interval_contains(a, b):
+    '''time interval a contains time interval b'''
+    return a[0] <= b[0] and a[1] >= b[1]
+
+
+def interval_overlaps(a, b):
+    '''time interval a and b contain some overlap'''
+    return max(a[0], b[0]) <= min(a[1], b[1])
+
+
+def get_moti_stations(connection_string):
+    engine = create_engine(connection_string)
+    Session = sessionmaker(engine)
+    sesh = Session()
+
+    q = sesh.query(Station.native_id).join(Network)\
+                                     .filter(Network.name == "MoTIe")
+    return [native_id for (native_id,) in q.all()]
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -124,7 +124,7 @@ def infill(networks, start_time, end_time, auth_fname, connection_string,
     if 'moti' in networks:
         # Query all of the stations
         stations = get_moti_stations(connection_string)
-        # Divide range into 7 day intervals
+        # Divide range into 6 day intervals
         for interval_start, interval_end in zip(
                 weekly_ranges[:-1], weekly_ranges[1:]):
             for station in stations:
@@ -228,7 +228,9 @@ def datetime_range(start, end, resolution='hour'):
     particularities. (MoTI allows you to specify a full time range
     rather than discrete days/hours). Using the week resoultion rounds
     the beginning time step down to the nearest day and then just uses
-    the end time as is.
+    the end time as is. During initial testing, we found that using
+    the full 7 day time range resulted in many HTTP 500 errors, so
+    we're using a conservative "week" of 6 days.
 
     Args:
         start (datetime.datetime): The beginnng of the range
@@ -241,7 +243,11 @@ def datetime_range(start, end, resolution='hour'):
     '''
     if resolution not in ('hour', 'day', 'week'):
         raise ValueError
-    kwargs = {resolution + 's': 1}
+    kwargs = {
+        'hour': {'hours': 1},
+        'day': {'days': 1},
+        'week': {'days': 6},
+    }[resolution]
     step = datetime.timedelta(**kwargs)
 
     # Don't round down to the week... just the day and end at the actual end

--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 from argparse import ArgumentParser
 from warnings import warn
-from subprocess import run
+from subprocess import run, PIPE
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -47,11 +47,11 @@ def main():
 def download_and_process(download_args, network_name, connection_string):
     proc = [f"download_{network_name}"] + download_args
     logger.debug(' '.join(proc))
-    dl_proc = run(proc, capture_output=True)
+    dl_proc = run(proc, stdout=PIPE)
     process = ["crmprtd_process", f"-c {connection_string}",
                f"-N {network_name}"]
     logger.debug(' '.join(process))
-    run(process, stdin=dl_proc.stdout)
+    run(process, input=dl_proc.stdout)
 
 
 def infill(start_time, end_time, auth_fname, connection_string):

--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -44,7 +44,8 @@ def main():
     s = datetime.datetime.strptime(args.start_time, '%Y/%m/%d %H:%M:%S')
     e = datetime.datetime.strptime(args.end_time, '%Y/%m/%d %H:%M:%S')
 
-    log_args = [(x, y) for (x, y) in zip(["-L", "-l", "-m", "-o"], log_args) if y]
+    log_args = [(x, y) for (x, y) in zip(["-L", "-l", "-m", "-o"], log_args)
+                if y]
     log_args = list(itertools.chain(*log_args))
 
     infill(s, e, args.auth_fname, args.connection_string, log_args)
@@ -80,9 +81,10 @@ def infill(start_time, end_time, auth_fname, connection_string,
     for freq, times in zip(('daily', 'hourly'), (daily_ranges, hourly_ranges)):
         for province in ('YT', 'BC'):
             for time in times:
-                dl_args = [f"-p {province}", f"-F {freq}", "-g e",
-                           f"-t {time.strftime(time_fmt)}"]
-                download_and_process(dl_args, "ec", connection_string)
+                dl_args = ["-p", province, "-F", freq, "-g" "e",
+                           "-t", time.strftime(time_fmt)]
+                download_and_process(dl_args, "ec", connection_string,
+                                     log_args)
 
     # MOTI
     # Query all of the stations

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "scripts/moti_infill_download.py",
         "scripts/moti_insert_files.py",
         "scripts/moti_infill_insert.py",
-        "scripts/infill_all.py"
     ],
     entry_points={
         'console_scripts': [
@@ -47,6 +46,7 @@ setup(
             'download_wamr=crmprtd.wamr.download:main',
             'download_wmb=crmprtd.wmb.download:main',
             'crmprtd_process=crmprtd.process:main',
+            'crmprtd_infill_all=scripts.infill_all:main'
         ]
     },
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         "scripts/ec_recovery.py",
         "scripts/moti_infill_download.py",
         "scripts/moti_insert_files.py",
-        "scripts/moti_infill_insert.py"
+        "scripts/moti_infill_insert.py",
+        "scripts/infill_all.py"
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This script can be used to infill some missed data for any set of
networks that are available in crmprtd. The script is minimally
configurable for ease of use. Simply give it a start time and end
time, and based on the network, it will compute whether it can make a
request for that time range. If it can, it will go out and download
all of the data for that time range, and the process it into the
database.

Only four parameters are required: a start time, end time, auth
details (for MoTI and WMB) and a database connection. Optionally you
can configure the loggging, and select a subset of available networks
to infill.
