### PR TITLE
Update images used

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -21,7 +21,7 @@ node {
 
     if (isPypiPublishable()) {
         stage('Push to PYPI') {
-            publishPythonPackage('crmprtd-test-python3.6', 'PCIC_PYPI_CREDS')
+            publishPythonPackage('crmprtd-test-env:python-3.6', 'PCIC_PYPI_CREDS')
         }
     }
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -12,10 +12,10 @@ node {
         def options = [containerData: 'crmprtd']
 
         parallel "Python 3.6": {
-            runPythonTestSuite('crmprtd-test-python3.6', requirements, pytestArgs, options)
+            runPythonTestSuite('pcic/crmprtd-test-env:python-3.6', requirements, pytestArgs, options)
         },
         "Python 3.7": {
-            runPythonTestSuite('crmprtd-test-python3.7', requirements, pytestArgs, options)
+            runPythonTestSuite('pcic/crmprtd-test-env:python-3.7', requirements, pytestArgs, options)
         }
     }
 


### PR DESCRIPTION
The test environment images used by `crmprtd` are now being stored in docker hub.  Docker hub conventions required that the name of the images be updated.