### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   test:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [3.6, 3.7]

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,6 +18,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get install postgresql-10-postgis-2.4
         pip install -U pip pytest
         pip install -r requirements.txt -r test_requirements.txt
         pip install .

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,15 +17,15 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      env:
+        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
         sudo apt-get install postgresql-10-postgis-2.4
         pip install -U pip pytest
         pip install -r requirements.txt -r test_requirements.txt
         pip install .
-      env:
-        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
     - name: Test with pytest
-      run: |
-        py.test -v --tb=short --cov --flake8
       env:
         TZ: Canada/Pacific
+      run: |
+        py.test -v --tb=short --cov --flake8

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,30 @@
+name: CI Tests
+
+on: push
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install -U pip pytest
+        pip install -r requirements.txt -r test_requirements.txt
+        pip install .
+      env:
+        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
+    - name: Test with pytest
+      run: |
+        py.test -v --tb=short --cov --flake8
+      env:
+        TZ: Canada/Pacific

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,8 +21,8 @@ jobs:
         pip install setuptools wheel twine
     - name: Build and publish
       env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_USERNAME: ${{ secrets.pcic_at_pypi_username }}
+        TWINE_PASSWORD: ${{ secrets.pcic_at_pypi_password }}
       run: |
         python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,28 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*


### PR DESCRIPTION
Adds github actions to the repo.  The workflows will take over the responsibilities of Jenkins and Travis which are:
- run python test suite (on all pushes)
- build and publish pypi package (on release creation)

I do not have permission to access the webhooks in this repo but Travis and Jenkins need to be deactivated.