### PR TITLE
Add --version arg to console scripts

### DIFF
--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -53,7 +53,6 @@ import logging.config
 import pkg_resources
 from pkg_resources import resource_stream
 from collections import namedtuple
-from itertools import tee
 
 SWOB_PARTNERS = (
     "bc_env_aq",
@@ -95,7 +94,7 @@ def add_logging_args(parser):
         "-L",
         "--log_conf",
         default=None,
-        help=("YAML file to use to override the default " "logging configuration"),
+        help="YAML file to use to override the default logging configuration",
     )
     parser.add_argument(
         "-l", "--log_filename", default=None, help="Override the default log filename"
@@ -137,7 +136,7 @@ def common_script_arguments(parser):  # pragma: no cover
         "-L",
         "--log_conf",
         default=None,
-        help=("YAML file to use to override the default " "logging configuration"),
+        help="YAML file to use to override the default logging configuration",
     )
     parser.add_argument(
         "-l", "--log_filename", default=None, help="Override the default log filename"
@@ -164,7 +163,7 @@ def common_script_arguments(parser):  # pragma: no cover
     parser.add_argument(
         "-C",
         "--cache_file",
-        help="Full path of file in which to put downloaded " "observations",
+        help="Full path of file in which to put downloaded observations",
     )
     parser.add_argument("-i", "--input_file", help="Input file to process")
     parser.add_argument(
@@ -183,13 +182,13 @@ def common_auth_arguments(parser):  # pragma: no cover
         "--auth_fname", help="Yaml file with plaintext usernames/passwords"
     )
     parser.add_argument(
-        "--auth_key", help=("Top level key which user/pass are stored in " "yaml file.")
+        "--auth_key", help="Top level key which user/pass are stored in yaml file."
     )
     parser.add_argument(
-        "--username", help=("The username for data requests. Overrides auth " "file.")
+        "--username", help="The username for data requests. Overrides auth file."
     )
     parser.add_argument(
-        "--password", help=("The password for data requests. Overrides auth " "file.")
+        "--password", help="The password for data requests. Overrides auth file."
     )
     return parser
 

--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -76,7 +76,7 @@ Row = namedtuple(
 )
 
 
-def logging_args(parser):
+def add_logging_args(parser):
     parser.add_argument(
         "-L",
         "--log_conf",

--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -50,6 +50,7 @@ speed and reliability. This phase is common to all networks.
 
 import logging
 import logging.config
+import pkg_resources
 from pkg_resources import resource_stream
 from collections import namedtuple
 from itertools import tee
@@ -74,6 +75,19 @@ Row = namedtuple(
     "Row",
     "time val variable_name unit network_name station_id lat lon",
 )
+
+
+def add_version_arg(parser):
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Output version number and exit",
+    )
+    return parser
+
+
+def get_version():
+    return pkg_resources.require("crmprtd")[0].version
 
 
 def add_logging_args(parser):

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -27,7 +27,7 @@ for def_ in (
     "degreeC = degC; offset: 273.15 = °C = celsius = Celsius",
     "degreeF = 5 / 9 * kelvin; offset: 255.372222",
     "degreeK = degK; offset: 0",
-    "degree = π / 180 * radian = deg = Deg = arcdeg = arcdegree = " "angular_degree",
+    "degree = π / 180 * radian = deg = Deg = arcdeg = arcdegree = angular_degree",
 ):
     ureg.define(def_)
 

--- a/crmprtd/bc_env_aq/download.py
+++ b/crmprtd/bc_env_aq/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("bc-env-aq")
+def main(args=None):
+    swob_main("bc-env-aq", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/bc_env_snow/download.py
+++ b/crmprtd/bc_env_snow/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("bc-env-snow")
+def main(args=None):
+    swob_main("bc-env-snow", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/bc_forestry/download.py
+++ b/crmprtd/bc_forestry/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("bc-forestry")
+def main(args=None):
+    swob_main("bc-forestry", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/bc_hydro/download.py
+++ b/crmprtd/bc_hydro/download.py
@@ -25,7 +25,7 @@ from dateutil import relativedelta
 import dateutil.parser
 
 from crmprtd.download import verify_date
-from crmprtd import logging_args, setup_logging
+from crmprtd import add_logging_args, setup_logging
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +115,7 @@ def download_relevant_bch_zipfiles(start_date, end_date, connection, remote_file
 def main():  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     parser.add_argument(
         "-u", "--username", default="pcic", help=("Username for the ftp server ")
     )

--- a/crmprtd/bc_hydro/download.py
+++ b/crmprtd/bc_hydro/download.py
@@ -112,7 +112,7 @@ def download_relevant_bch_zipfiles(start_date, end_date, connection, remote_file
                 sys.stdout.buffer.write(txt_file.read())
 
 
-def main():  # pragma: no cover
+def main(args=None):  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
     add_version_arg(parser)
@@ -135,7 +135,6 @@ def main():  # pragma: no cover
     parser.add_argument(
         "-S",
         "--ssh_private_key",
-        required=True,
         help=("Path to file with SSH private key"),
     )
     end = datetime.now()
@@ -158,7 +157,7 @@ def main():  # pragma: no cover
             "Defaults to now."
         ),
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if args.version:
         print(get_version())

--- a/crmprtd/bc_hydro/download.py
+++ b/crmprtd/bc_hydro/download.py
@@ -25,7 +25,7 @@ from dateutil import relativedelta
 import dateutil.parser
 
 from crmprtd.download import verify_date
-from crmprtd import add_logging_args, setup_logging
+from crmprtd import add_logging_args, setup_logging, get_version, add_version_arg
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +115,8 @@ def download_relevant_bch_zipfiles(start_date, end_date, connection, remote_file
 def main():  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = add_logging_args(parser)
+    add_version_arg(parser)
+    add_logging_args(parser)
     parser.add_argument(
         "-u", "--username", default="pcic", help=("Username for the ftp server ")
     )
@@ -158,6 +159,10 @@ def main():  # pragma: no cover
         ),
     )
     args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return
 
     setup_logging(
         args.log_conf,

--- a/crmprtd/bc_hydro/download.py
+++ b/crmprtd/bc_hydro/download.py
@@ -16,13 +16,12 @@ import sys
 import re
 from zipfile import ZipFile
 from argparse import ArgumentParser
-from datetime import date, timedelta, datetime
+from datetime import datetime
 from functools import partial
 from tempfile import mkstemp
 from contextlib import contextmanager
 
 from dateutil import relativedelta
-import dateutil.parser
 
 from crmprtd.download import verify_date
 from crmprtd import add_logging_args, setup_logging, get_version, add_version_arg
@@ -118,24 +117,24 @@ def main(args=None):  # pragma: no cover
     add_version_arg(parser)
     add_logging_args(parser)
     parser.add_argument(
-        "-u", "--username", default="pcic", help=("Username for the ftp server ")
+        "-u", "--username", default="pcic", help="Username for the ftp server "
     )
     parser.add_argument(
         "-f",
         "--ftp_server",
         default="sftp2.bchydro.com",
-        help=("Full uri to BC Hydro's ftp " "server"),
+        help="Full uri to BC Hydro's ftp server",
     )
     parser.add_argument(
         "-F",
         "--ftp_dir",
         default=("pcic"),
-        help=("FTP Directory containing BC hydro's " "data files"),
+        help="FTP Directory containing BC hydro's data files",
     )
     parser.add_argument(
         "-S",
         "--ssh_private_key",
-        help=("Path to file with SSH private key"),
+        help="Path to file with SSH private key",
     )
     end = datetime.now()
     start = end - relativedelta.relativedelta(months=1)

--- a/crmprtd/bc_tran/download.py
+++ b/crmprtd/bc_tran/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("bc-tran")
+def main(args=None):
+    swob_main("bc-tran", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/crd/download.py
+++ b/crmprtd/crd/download.py
@@ -25,7 +25,10 @@ import dateutil.parser
 
 import crmprtd.download
 from crmprtd import (
-    add_logging_args, setup_logging, common_auth_arguments, add_version_arg,
+    add_logging_args,
+    setup_logging,
+    common_auth_arguments,
+    add_version_arg,
     get_version,
 )
 

--- a/crmprtd/crd/download.py
+++ b/crmprtd/crd/download.py
@@ -24,7 +24,9 @@ from datetime import timedelta
 import dateutil.parser
 
 import crmprtd.download
-from crmprtd import add_logging_args, setup_logging, common_auth_arguments
+from crmprtd import (
+    add_logging_args, setup_logging, common_auth_arguments, add_version_arg,
+)
 
 log = logging.getLogger(__name__)
 
@@ -68,8 +70,9 @@ def download(client_id, start_date, end_date):  # pragma: no cover
 def main():  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = add_logging_args(parser)
-    parser = common_auth_arguments(parser)
+    add_version_arg(parser)
+    add_logging_args(parser)
+    common_auth_arguments(parser)
     parser.add_argument(
         "-S",
         "--start_time",

--- a/crmprtd/crd/download.py
+++ b/crmprtd/crd/download.py
@@ -24,7 +24,7 @@ from datetime import timedelta
 import dateutil.parser
 
 import crmprtd.download
-from crmprtd import logging_args, setup_logging, common_auth_arguments
+from crmprtd import add_logging_args, setup_logging, common_auth_arguments
 
 log = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ def download(client_id, start_date, end_date):  # pragma: no cover
 def main():  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     parser = common_auth_arguments(parser)
     parser.add_argument(
         "-S",

--- a/crmprtd/crd/download.py
+++ b/crmprtd/crd/download.py
@@ -26,6 +26,7 @@ import dateutil.parser
 import crmprtd.download
 from crmprtd import (
     add_logging_args, setup_logging, common_auth_arguments, add_version_arg,
+    get_version,
 )
 
 log = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ def download(client_id, start_date, end_date):  # pragma: no cover
         sys.exit(1)
 
 
-def main():  # pragma: no cover
+def main(args=None):  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
     add_version_arg(parser)
@@ -93,7 +94,11 @@ def main():  # pragma: no cover
             "Defaults to now."
         ),
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args)
+
+    if args.version:
+        print(get_version())
+        return
 
     setup_logging(
         args.log_conf,

--- a/crmprtd/dfo_ccg_lighthouse/download.py
+++ b/crmprtd/dfo_ccg_lighthouse/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("dfo-ccg-lighthouse")
+def main(args=None):
+    swob_main("dfo-ccg-lighthouse", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -55,12 +55,12 @@ def download(time, frequency, province, language, baseurl):
         sys.exit(1)
 
 
-def main():
+def main(args=None):
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
     add_version_arg(parser)
     parser.add_argument(
-        "-p", "--province", required=True, help="2 letter province code"
+        "-p", "--province", help="2 letter province code"
     )
     parser.add_argument(
         "-g",
@@ -72,7 +72,6 @@ def main():
     parser.add_argument(
         "-F",
         "--frequency",
-        required=True,
         choices=["daily", "hourly"],
         help="daily|hourly",
     )
@@ -107,7 +106,7 @@ def main():
         ),
     )
     add_logging_args(parser)
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if args.version:
         print(get_version())

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -16,7 +16,6 @@ result in data loss.
 
 # Standard module
 import sys
-import logging
 import logging.config
 from datetime import datetime, timedelta
 from argparse import ArgumentParser
@@ -59,9 +58,7 @@ def main(args=None):
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
     add_version_arg(parser)
-    parser.add_argument(
-        "-p", "--province", help="2 letter province code"
-    )
+    parser.add_argument("-p", "--province", help="2 letter province code")
     parser.add_argument(
         "-g",
         "--language",

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -23,7 +23,7 @@ from argparse import ArgumentParser
 
 # Local
 from crmprtd.ec import makeurl
-from crmprtd import setup_logging, add_logging_args
+from crmprtd import setup_logging, add_logging_args, add_version_arg, get_version
 from crmprtd.download import https_download, verify_date
 
 log = logging.getLogger(__name__)
@@ -58,6 +58,7 @@ def download(time, frequency, province, language, baseurl):
 def main():
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
+    add_version_arg(parser)
     parser.add_argument(
         "-p", "--province", required=True, help="2 letter province code"
     )
@@ -105,8 +106,12 @@ def main():
             "the meteorological observations service"
         ),
     )
-    parser = add_logging_args(parser)
+    add_logging_args(parser)
     args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return
 
     setup_logging(
         args.log_conf, args.log_filename, args.error_email, args.log_level, "crmprtd.ec"

--- a/crmprtd/ec/download.py
+++ b/crmprtd/ec/download.py
@@ -23,7 +23,7 @@ from argparse import ArgumentParser
 
 # Local
 from crmprtd.ec import makeurl
-from crmprtd import setup_logging, logging_args
+from crmprtd import setup_logging, add_logging_args
 from crmprtd.download import https_download, verify_date
 
 log = logging.getLogger(__name__)
@@ -105,7 +105,7 @@ def main():
             "the meteorological observations service"
         ),
     )
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     args = parser.parse_args()
 
     setup_logging(

--- a/crmprtd/ec_swob/download.py
+++ b/crmprtd/ec_swob/download.py
@@ -24,8 +24,7 @@ from lxml import html
 import requests
 
 from crmprtd.download import https_download, verify_date
-from crmprtd import add_logging_args, setup_logging
-
+from crmprtd import add_logging_args, setup_logging, add_version_arg, get_version
 
 log = logging.getLogger(__name__)
 
@@ -126,7 +125,8 @@ def main(partner):
     """
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = add_logging_args(parser)
+    add_version_arg(parser)
+    add_logging_args(parser)
     parser.add_argument(
         "-d",
         "--date",
@@ -137,6 +137,10 @@ def main(partner):
         ),
     )
     args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return
 
     setup_logging(
         args.log_conf,

--- a/crmprtd/ec_swob/download.py
+++ b/crmprtd/ec_swob/download.py
@@ -109,7 +109,7 @@ def split_multi_xml_stream(stream):
         yield rv
 
 
-def main(partner):
+def main(partner, args=None):
     """Main download function to use for download scripts for the EC_SWOB
     provincial partners (e.g. bc-env-snow, bc-env-aq, bc-forestry and
     bc-tran).
@@ -117,6 +117,7 @@ def main(partner):
     Args:
         partner (str): The partner abbreviation found in the SWOB URL
         (e.g. bc-tran)
+        args (list): Argument list (for testing; default is to parse from sys.argv).
 
     Returns:
         No return value. Produces side-effect of sending downloaded
@@ -136,7 +137,7 @@ def main(partner):
             "Defaults to now."
         ),
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if args.version:
         print(get_version())

--- a/crmprtd/ec_swob/download.py
+++ b/crmprtd/ec_swob/download.py
@@ -24,7 +24,7 @@ from lxml import html
 import requests
 
 from crmprtd.download import https_download, verify_date
-from crmprtd import logging_args, setup_logging
+from crmprtd import add_logging_args, setup_logging
 
 
 log = logging.getLogger(__name__)
@@ -126,7 +126,7 @@ def main(partner):
     """
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     parser.add_argument(
         "-d",
         "--date",

--- a/crmprtd/ec_swob/download.py
+++ b/crmprtd/ec_swob/download.py
@@ -30,7 +30,7 @@ log = logging.getLogger(__name__)
 
 
 def get_url_list(
-    base_url="https://dd.weather.gc.ca/observations/swob-ml/partners/" "bc-env-snow/",
+    base_url="https://dd.weather.gc.ca/observations/swob-ml/partners/bc-env-snow/",
     date=datetime.datetime.now(),
 ):
     """Recursively search an HTML directory tree and yield a set of

--- a/crmprtd/infill.py
+++ b/crmprtd/infill.py
@@ -180,7 +180,7 @@ def round_datetime(d, resolution="hour", direction="down"):
         pass
     else:
         raise ValueError(
-            f"resolution parameter can only be 'hour' or 'day' " "not '{resolution}'"
+            f"resolution parameter can only be 'hour' or 'day' not '{resolution}'"
         )
     if d_prime == d:
         return d

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -29,7 +29,7 @@ from argparse import ArgumentParser
 
 # Local
 import crmprtd.download
-from crmprtd import common_auth_arguments, logging_args, setup_logging
+from crmprtd import common_auth_arguments, add_logging_args, setup_logging
 
 log = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ def download(
 def main():  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     parser = common_auth_arguments(parser)
     parser.add_argument(
         "-S",

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -29,7 +29,10 @@ from argparse import ArgumentParser
 
 # Local
 import crmprtd.download
-from crmprtd import common_auth_arguments, add_logging_args, setup_logging, get_version
+from crmprtd import (
+    common_auth_arguments, add_logging_args, setup_logging, get_version,
+    add_version_arg,
+)
 
 log = logging.getLogger(__name__)
 
@@ -90,9 +93,10 @@ def download(
         sys.exit(1)
 
 
-def main():  # pragma: no cover
+def main(args=None):  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
+    add_version_arg(parser)
     add_logging_args(parser)
     common_auth_arguments(parser)
     parser.add_argument(
@@ -122,7 +126,7 @@ def main():  # pragma: no cover
         default="https://prdoas5.apps.th.gov.bc.ca/saw-data/sawr7110",
         help="Base URL for the MoTI SAW service",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if args.version:
         print(get_version())

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -20,9 +20,7 @@ little risk of missing data.
 
 # Standard module
 import sys
-import logging
 import logging.config
-from warnings import warn
 from datetime import datetime, timedelta
 from argparse import ArgumentParser
 
@@ -30,7 +28,10 @@ from argparse import ArgumentParser
 # Local
 import crmprtd.download
 from crmprtd import (
-    common_auth_arguments, add_logging_args, setup_logging, get_version,
+    common_auth_arguments,
+    add_logging_args,
+    setup_logging,
+    get_version,
     add_version_arg,
 )
 

--- a/crmprtd/moti/download.py
+++ b/crmprtd/moti/download.py
@@ -29,7 +29,7 @@ from argparse import ArgumentParser
 
 # Local
 import crmprtd.download
-from crmprtd import common_auth_arguments, add_logging_args, setup_logging
+from crmprtd import common_auth_arguments, add_logging_args, setup_logging, get_version
 
 log = logging.getLogger(__name__)
 
@@ -93,8 +93,8 @@ def download(
 def main():  # pragma: no cover
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = add_logging_args(parser)
-    parser = common_auth_arguments(parser)
+    add_logging_args(parser)
+    common_auth_arguments(parser)
     parser.add_argument(
         "-S",
         "--start_time",
@@ -123,6 +123,10 @@ def main():  # pragma: no cover
         help="Base URL for the MoTI SAW service",
     )
     args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return
 
     setup_logging(
         args.log_conf,

--- a/crmprtd/moti/normalize.py
+++ b/crmprtd/moti/normalize.py
@@ -48,7 +48,7 @@ def normalize(file_stream):
             time = member.get("valid-time")
             if not time:
                 log.warning(
-                    "Could not find a valid-time attribute for this " "observation"
+                    "Could not find a valid-time attribute for this observation"
                 )
                 continue
 

--- a/crmprtd/nt_forestry/download.py
+++ b/crmprtd/nt_forestry/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("nt-forestry")
+def main(args=None):
+    swob_main("nt-forestry", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/nt_water/download.py
+++ b/crmprtd/nt_water/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("nt-water")
+def main(args=None):
+    swob_main("nt-water", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -13,10 +13,10 @@ from crmprtd.align import align
 from crmprtd.insert import insert
 from crmprtd.download import verify_date
 from crmprtd.infer import infer
-from crmprtd import logging_args, setup_logging, NETWORKS
+from crmprtd import add_logging_args, setup_logging, NETWORKS
 
 
-def process_args(parser):  # pragma: no cover
+def add_process_args(parser):  # pragma: no cover
     parser.add_argument(
         "-c", "--connection_string", help="PostgreSQL connection string", required=True
     )
@@ -178,8 +178,8 @@ def run_data_pipeline(
 
 def main():
     parser = ArgumentParser()
-    parser = process_args(parser)
-    parser = logging_args(parser)
+    add_process_args(parser)
+    add_logging_args(parser)
     args = parser.parse_args()
 
     setup_logging(

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -13,12 +13,18 @@ from crmprtd.align import align
 from crmprtd.insert import insert
 from crmprtd.download import verify_date
 from crmprtd.infer import infer
-from crmprtd import add_logging_args, setup_logging, NETWORKS
+from crmprtd import (
+    add_version_arg,
+    add_logging_args,
+    setup_logging,
+    NETWORKS,
+    get_version,
+)
 
 
 def add_process_args(parser):  # pragma: no cover
     parser.add_argument(
-        "-c", "--connection_string", help="PostgreSQL connection string", required=True
+        "-c", "--connection_string", help="PostgreSQL connection string"
     )
     parser.add_argument(
         "-D",
@@ -178,6 +184,7 @@ def run_data_pipeline(
 
 def main():
     parser = ArgumentParser()
+    add_version_arg(parser)
     add_process_args(parser)
     add_logging_args(parser)
     args = parser.parse_args()
@@ -185,6 +192,10 @@ def main():
     setup_logging(
         args.log_conf, args.log_filename, args.error_email, args.log_level, "crmprtd"
     )
+
+    if args.version:
+        print(get_version())
+        return
 
     utc = pytz.utc
 
@@ -194,13 +205,13 @@ def main():
     args.end_date = utc.localize(verify_date(args.end_date, datetime.max, "end date"))
 
     process(
-        args.connection_string,
-        args.sample_size,
-        args.network,
-        args.start_date,
-        args.end_date,
-        args.diag,
-        args.infer,
+        connection_string=args.connection_string,
+        sample_size=args.sample_size,
+        network=args.network,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        is_diagnostic=args.diag,
+        do_infer=args.infer,
     )
 
 

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -182,12 +182,12 @@ def run_data_pipeline(
     log.info("Data insertion results", extra={"results": results})
 
 
-def main():
+def main(args=None):
     parser = ArgumentParser()
     add_version_arg(parser)
     add_process_args(parser)
     add_logging_args(parser)
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     setup_logging(
         args.log_conf, args.log_filename, args.error_email, args.log_level, "crmprtd"

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -81,7 +81,7 @@ class WAMRFTPReader(FTPReader):
         self.connection.retrlines("NLST " + data_path, callback)
 
 
-def main():
+def main(args=None):
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
     add_version_arg(parser)
@@ -100,7 +100,7 @@ def main():
         help="FTP Directory containing WAMR's data files",
     )
     parser = add_logging_args(parser)
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if args.version:
         print(get_version())

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -21,7 +21,7 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.download import retry, ftp_connect
 from crmprtd.download import FTPReader
-from crmprtd import logging_args, setup_logging
+from crmprtd import add_logging_args, setup_logging
 
 
 log = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ def main():
         default=("pub/outgoing/AIR/Hourly_Raw_Air_Data/" "Meteorological/"),
         help="FTP Directory containing WAMR's data files",
     )
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     args = parser.parse_args()
 
     setup_logging(

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -90,13 +90,13 @@ def main(args=None):
         "--ftp_server",
         default="ftp.env.gov.bc.ca",
         help=(
-            "Full hostname of Water and Air Monitoring and " "Reporting's ftp server"
+            "Full hostname of Water and Air Monitoring and Reporting's ftp server"
         ),
     )
     parser.add_argument(
         "-F",
         "--ftp_dir",
-        default=("pub/outgoing/AIR/Hourly_Raw_Air_Data/" "Meteorological/"),
+        default="pub/outgoing/AIR/Hourly_Raw_Air_Data/Meteorological/",
         help="FTP Directory containing WAMR's data files",
     )
     parser = add_logging_args(parser)

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -21,8 +21,7 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.download import retry, ftp_connect
 from crmprtd.download import FTPReader
-from crmprtd import add_logging_args, setup_logging
-
+from crmprtd import add_logging_args, setup_logging, get_version, add_version_arg
 
 log = logging.getLogger(__name__)
 
@@ -85,6 +84,7 @@ class WAMRFTPReader(FTPReader):
 def main():
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
+    add_version_arg(parser)
     parser.add_argument(
         "-f",
         "--ftp_server",
@@ -101,6 +101,10 @@ def main():
     )
     parser = add_logging_args(parser)
     args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return
 
     setup_logging(
         args.log_conf,

--- a/crmprtd/wamr/download.py
+++ b/crmprtd/wamr/download.py
@@ -89,9 +89,7 @@ def main(args=None):
         "-f",
         "--ftp_server",
         default="ftp.env.gov.bc.ca",
-        help=(
-            "Full hostname of Water and Air Monitoring and Reporting's ftp server"
-        ),
+        help=("Full hostname of Water and Air Monitoring and Reporting's ftp server"),
     )
     parser.add_argument(
         "-F",

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -12,7 +12,6 @@ greater than 24 hours, you will miss data.
 
 # Standard module
 import os
-import logging
 import logging.config
 import ftplib
 import sys
@@ -23,7 +22,10 @@ from argparse import ArgumentParser
 from crmprtd.download import retry, ftp_connect
 from crmprtd.download import FTPReader, extract_auth
 from crmprtd import (
-    add_logging_args, setup_logging, common_auth_arguments, add_version_arg,
+    add_logging_args,
+    setup_logging,
+    common_auth_arguments,
+    add_version_arg,
     get_version,
 )
 

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -85,13 +85,13 @@ def main(args=None):
         "-f",
         "--ftp_server",
         default="BCFireweatherFTPp1.nrs.gov.bc.ca",
-        help=("Full uri to Wildfire Management Branch's ftp " "server"),
+        help="Full uri to Wildfire Management Branch's ftp server",
     )
     parser.add_argument(
         "-F",
         "--ftp_file",
         default="HourlyWeatherAllFields_WA.txt",
-        help=("Filename to open on the Wildfire Management " "Branch's ftp site"),
+        help="Filename to open on the Wildfire Management Branch's ftp site",
     )
     args = parser.parse_args(args)
 

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -22,7 +22,7 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.download import retry, ftp_connect
 from crmprtd.download import FTPReader, extract_auth
-from crmprtd import logging_args, setup_logging, common_auth_arguments
+from crmprtd import add_logging_args, setup_logging, common_auth_arguments
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class WMBFTPReader(FTPReader):
 def main():
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     parser = common_auth_arguments(parser)
     parser.add_argument(
         "-f",

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -22,7 +22,10 @@ from argparse import ArgumentParser
 # Local
 from crmprtd.download import retry, ftp_connect
 from crmprtd.download import FTPReader, extract_auth
-from crmprtd import add_logging_args, setup_logging, common_auth_arguments
+from crmprtd import (
+    add_logging_args, setup_logging, common_auth_arguments, add_version_arg,
+    get_version,
+)
 
 log = logging.getLogger(__name__)
 
@@ -73,8 +76,9 @@ class WMBFTPReader(FTPReader):
 def main():
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
-    parser = add_logging_args(parser)
-    parser = common_auth_arguments(parser)
+    add_version_arg(parser)
+    add_logging_args(parser)
+    common_auth_arguments(parser)
     parser.add_argument(
         "-f",
         "--ftp_server",
@@ -88,6 +92,10 @@ def main():
         help=("Filename to open on the Wildfire Management " "Branch's ftp site"),
     )
     args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return
 
     setup_logging(
         args.log_conf,

--- a/crmprtd/wmb/download.py
+++ b/crmprtd/wmb/download.py
@@ -73,7 +73,7 @@ class WMBFTPReader(FTPReader):
         self.connection = ftp_connect_with_retry(host, user, password)
 
 
-def main():
+def main(args=None):
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
     add_version_arg(parser)
@@ -91,7 +91,7 @@ def main():
         default="HourlyWeatherAllFields_WA.txt",
         help=("Filename to open on the Wildfire Management " "Branch's ftp site"),
     )
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if args.version:
         print(get_version())

--- a/crmprtd/yt_avalanche/download.py
+++ b/crmprtd/yt_avalanche/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("yt-avalanche")
+def main(args=None):
+    swob_main("yt-avalanche", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/yt_firewx/download.py
+++ b/crmprtd/yt_firewx/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("yt-firewx")
+def main(args=None):
+    swob_main("yt-firewx", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/yt_gov/download.py
+++ b/crmprtd/yt_gov/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("yt-gov")
+def main(args=None):
+    swob_main("yt-gov", args)
 
 
 if __name__ == "__main__":

--- a/crmprtd/yt_water/download.py
+++ b/crmprtd/yt_water/download.py
@@ -1,8 +1,8 @@
 from crmprtd.ec_swob.download import main as swob_main
 
 
-def main():
-    swob_main("yt-water")
+def main(args=None):
+    swob_main("yt-water", args)
 
 
 if __name__ == "__main__":

--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -24,7 +24,7 @@ from crmprtd import add_logging_args, setup_logging, add_version_arg, get_versio
 from crmprtd.infill import infill
 
 
-def main():
+def main(args=None):
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
     add_version_arg(parser)
@@ -68,7 +68,7 @@ def main():
     )
 
     parser = add_logging_args(parser)
-    args = parser.parse_args()
+    args = parser.parse_args(args)
 
     if args.version:
         print(get_version())

--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -20,7 +20,7 @@ import itertools
 
 from dateutil.tz import tzlocal
 
-from crmprtd import logging_args, setup_logging
+from crmprtd import add_logging_args, setup_logging
 from crmprtd.infill import infill
 
 
@@ -66,7 +66,7 @@ def main():
         help="Set of networks for which to infill",
     )
 
-    parser = logging_args(parser)
+    parser = add_logging_args(parser)
     args = parser.parse_args()
 
     log_args = [

--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -20,13 +20,14 @@ import itertools
 
 from dateutil.tz import tzlocal
 
-from crmprtd import add_logging_args, setup_logging
+from crmprtd import add_logging_args, setup_logging, add_version_arg, get_version
 from crmprtd.infill import infill
 
 
 def main():
     desc = globals()["__doc__"]
     parser = ArgumentParser(description=desc)
+    add_version_arg(parser)
     parser.add_argument(
         "-S",
         "--start_time",
@@ -56,7 +57,7 @@ def main():
         "those networks.",
     )
     parser.add_argument(
-        "-c", "--connection_string", help="PostgreSQL connection string", required=True
+        "-c", "--connection_string", help="PostgreSQL connection string"
     )
     parser.add_argument(
         "-N",
@@ -68,6 +69,10 @@ def main():
 
     parser = add_logging_args(parser)
     args = parser.parse_args()
+
+    if args.version:
+        print(get_version())
+        return
 
     log_args = [
         args.log_conf,

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,16 @@
+import pytest
+import crmprtd
+from crmprtd import get_version
+
+
+@pytest.mark.parametrize(
+    "name, entry_point",
+    [
+        (name, ep.load()) for name, ep in
+        crmprtd.pkg_resources.get_entry_map("crmprtd")["console_scripts"].items()
+    ]
+)
+def test_version(capsys, name, entry_point):
+    entry_point(["--version"])
+    captured = capsys.readouterr()
+    assert captured.out == f"{get_version()}\n"

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -6,9 +6,11 @@ from crmprtd import get_version
 @pytest.mark.parametrize(
     "name, entry_point",
     [
-        (name, ep.load()) for name, ep in
-        crmprtd.pkg_resources.get_entry_map("crmprtd")["console_scripts"].items()
-    ]
+        (name, ep.load())
+        for name, ep in crmprtd.pkg_resources.get_entry_map("crmprtd")[
+            "console_scripts"
+        ].items()
+    ],
 )
 def test_version(capsys, name, entry_point):
     entry_point(["--version"])


### PR DESCRIPTION
Resolves #120

This PR also:
- Slightly modifies the arguments to the scripts: In order to permit --version to do its thing (without having to specify unnecessary arguments), all formerly required arguments are now optional.
- Makes the script entrypoints (`main`) more testable by allowing the caller to pass in "command line" arguments. Default remains to get them from `sys.argv`, which is the actual command line args. 
- Cleans up some weird code formatting that might be left over from a change of Black line length or something like that.