### PR TITLE
Use distance ordering in spatially matched histories

### DIFF
--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -83,7 +83,7 @@ def history_ids_within_threshold(sesh, network_name, lon, lat, threshold):
         .all()
     )
 
-    return {hx.history_id for hx in network_hxs_within_threshold}
+    return [hx.history_id for hx in network_hxs_within_threshold]
 
 
 def convert_unit(val, src_unit, dst_unit):

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -42,19 +42,23 @@ for def_ in (
 
 def histories_within_threshold(sesh, network_name, lon, lat, threshold):
     """
-    Return existing histories associated with the given network and within a threshold
-    distance of the point specified by (lon, lat).
+    Find existing histories associated with the given network and within a threshold
+    distance of the point specified by (lon, lat). Return the history id and distance
+    for each such history, as a list in ascending order of distance.
 
     :param sesh: SQLAlchemy db session
     :param network_name: Name of network associated to history.
     :param lat: Lat for History
     :param lon: Lon for History
     :param threshold: Include only histories within this distance (m) from (lat, lon)
-    :return: List of records containing history_id, distance
+    :return: List of records with attributes history_id, distance, in ascending order
+        of distance.
     """
 
-    # Histories in network AND within threshold distance of (lon, lat).
+    # Construct reference point at (lon, lat) for distance computations.
     p_ref = cast(ST_SetSRID(ST_MakePoint(lon, lat), 4326), Geography)
+
+    # Histories in network AND within threshold distance of (lon, lat).
     hxs_within_threshold = (
         sesh.query(
             History.id.label("history_id"),

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -8,7 +8,7 @@ from crmprtd.align import (
     get_variable,
     convert_obs_value_to_db_units,
     align,
-    history_ids_within_threshold,
+    histories_within_threshold,
     convert_unit,
 )
 from crmprtd import Row
@@ -335,7 +335,7 @@ def test_align_failures(test_session, obs_tuple):
 
 
 def test_closest_stns_within_threshold(ec_session):
-    x = history_ids_within_threshold(ec_session, "EC_raw", -123.7, 49.45, 1000)
+    x = histories_within_threshold(ec_session, "EC_raw", -123.7, 49.45, 1000)
     assert len(x) > 0
 
 
@@ -356,7 +356,7 @@ def test_closest_stns_within_threshold_bad_data(ec_session):
     ec_session.commit()
 
     # Just search for the good station and ensure there are not errors
-    x = history_ids_within_threshold(ec_session, "EC_raw", x, y, 1)
+    x = histories_within_threshold(ec_session, "EC_raw", x, y, 1)
     assert len(x) > 0
 
 


### PR DESCRIPTION
Resolves #117 

This PR also:
- Propagates the computed distance further into the code where it could be (but is not presently) used.
- Reformulates the query for histories within threshold distance in SQLAlchemy and improves its efficiency. 