### PR TITLE
Catch and log all errors

### DIFF
--- a/crmprtd/download.py
+++ b/crmprtd/download.py
@@ -22,6 +22,7 @@ to scripts that use it.
 from typing import List
 from importlib import import_module
 from argparse import ArgumentParser
+import logging
 
 from crmprtd import (
     add_version_arg,
@@ -30,32 +31,38 @@ from crmprtd import (
 )
 
 
+log = logging.getLogger(__name__)
+
+
 def get_download_module(network):
     return import_module(f"crmprtd.networks.{network}.download")
 
 
 def main(arglist: List[str] = None):
-    parser = ArgumentParser(add_help=False)
+    try:
+        parser = ArgumentParser(add_help=False)
 
-    # Basic args
-    add_version_arg(parser)
-    add_logging_args(parser)
+        # Basic args
+        add_version_arg(parser)
+        add_logging_args(parser)
 
-    # Network arg
-    parser.add_argument(
-        "-N",
-        "--network",
-        required=True,
-        choices=NETWORKS,
-        help="Network from which to download observations",
-    )
+        # Network arg
+        parser.add_argument(
+            "-N",
+            "--network",
+            required=True,
+            choices=NETWORKS,
+            help="Network from which to download observations",
+        )
 
-    # parse_known_args allows unrecognized args to be present.
-    args, _ = parser.parse_known_args(arglist)
+        # parse_known_args allows unrecognized args to be present.
+        args, _ = parser.parse_known_args(arglist)
 
-    # Each download module adds its own network-specific args.
-    download_module = get_download_module(args.network)
-    download_module.main(arglist=arglist, parent_parser=parser)
+        # Each download module adds its own network-specific args.
+        download_module = get_download_module(args.network)
+        download_module.main(arglist=arglist, parent_parser=parser)
+    except Exception:
+        log.exception("Unhandled exception during 'download'")
 
 
 if __name__ == "__main__":

--- a/crmprtd/download_utils.py
+++ b/crmprtd/download_utils.py
@@ -85,7 +85,7 @@ class FTPReader(object):
         # Just store the lines in memory
         # It's non-ideal but neither classes support coroutine send/yield
         if not log:
-            log = logging.getLogger("__name__")
+            log = logging.getLogger(__name__)
         lines = []
 
         def callback(line):

--- a/crmprtd/download_utils.py
+++ b/crmprtd/download_utils.py
@@ -4,11 +4,13 @@ import ftplib
 import logging
 import csv
 import dateutil.parser
-from warnings import warn
 from functools import wraps
 
 import yaml
 import requests
+
+
+log = logging.getLogger(__name__)
 
 
 def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
@@ -171,7 +173,7 @@ def verify_date(datestring, default, label="date/time"):
     try:
         return dateutil.parser.parse(datestring)
     except (ValueError, TypeError):
-        warn(
+        log.warning(
             f"Parameter {label} '{datestring}' is undefined or unparseable. Using the "
             f"default '{default:%Y-%m-%d %H:%M:%S}'"
         )

--- a/crmprtd/infer.py
+++ b/crmprtd/infer.py
@@ -36,7 +36,7 @@ from pycds import Network, Variable
 from crmprtd.align import get_variable, find_or_create_matching_history_and_station
 
 
-log = logging.getLogger("crmprtd")
+log = logging.getLogger(__name__)
 
 
 def create_variable(

--- a/crmprtd/infill.py
+++ b/crmprtd/infill.py
@@ -2,7 +2,6 @@ import re
 import logging
 import datetime
 from typing import List, TextIO, Optional
-from warnings import warn
 from subprocess import run, PIPE
 
 from sqlalchemy import create_engine
@@ -84,7 +83,7 @@ def download_and_process(
     do_download = do_cache or do_process
 
     if not do_download:
-        warn(
+        logger.warning(
             f"Network {network_name}: Data is to be neither cached nor processed. "
             f"Nothing to do."
         )
@@ -263,10 +262,10 @@ def infill(
         last_month = (now - datetime.timedelta(days=30), now)
         # Warn if not
         if not interval_overlaps((start_time, end_time), last_month):
-            warn(warning_msg["disjoint"].format("WAMR", "one month"))
+            logger.warning(warning_msg["disjoint"].format("WAMR", "one month"))
         else:
             if not interval_contains((start_time, end_time), last_month):
-                warn(warning_msg["not_contained"].format("WAMR", "one_month"))
+                logger.warning(warning_msg["not_contained"].format("WAMR", "one_month"))
             dl_args = []
             download_and_process(
                 network_name="wamr",
@@ -282,10 +281,10 @@ def infill(
         # Check that the interval overlaps with the last day
         # Warn if not
         if not interval_overlaps((start_time, end_time), yesterday):
-            warn(warning_msg["disjoint"].format("WMB", "day"))
+            logger.warning(warning_msg["disjoint"].format("WMB", "day"))
         else:
             if not interval_contains((start_time, end_time), yesterday):
-                warn(warning_msg["not_contained"].format("WMB", "day"))
+                logger.warning(warning_msg["not_contained"].format("WMB", "day"))
             # Run it
             dl_args = ["--auth_fname", auth_fname, "--auth_key", "wmb"]
             download_and_process(

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -18,7 +18,7 @@ from crmprtd.db_exceptions import InsertionError
 from pycds import Obs
 
 
-log = logging.getLogger("crmprtd.insert")
+log = logging.getLogger(__name__)
 
 
 class DBMetrics(object):

--- a/crmprtd/networks/bc_hydro/normalize.py
+++ b/crmprtd/networks/bc_hydro/normalize.py
@@ -32,7 +32,7 @@ def normalize(file_stream):
         with resource_stream("crmprtd", variable_substitutions_path) as f:
             variable_substitutions = yaml.safe_load(f)
     except FileNotFoundError:
-        log.warn(
+        log.warning(
             f"Cannot open resource file '{variable_substitutions_path}'. "
             f"Proceeding with normalization, but there's a risk that variable names will not be recognized."
         )

--- a/crmprtd/networks/bc_hydro/normalize.py
+++ b/crmprtd/networks/bc_hydro/normalize.py
@@ -13,7 +13,7 @@ import pytz
 from crmprtd import Row
 from crmprtd import setup_logging
 
-log = logging.getLogger("crmprtd")
+log = logging.getLogger(__name__)
 
 
 def normalize(file_stream):

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -21,6 +21,7 @@ from crmprtd import (
     NETWORKS,
 )
 
+
 log = logging.getLogger(__name__)
 
 
@@ -199,32 +200,41 @@ def run_data_pipeline(
 
 
 def main(args=None):
-    parser = ArgumentParser()
-    add_version_arg(parser)
-    add_process_args(parser)
-    add_logging_args(parser)
-    args = parser.parse_args(args)
+    try:
+        parser = ArgumentParser()
+        add_version_arg(parser)
+        add_process_args(parser)
+        add_logging_args(parser)
+        args = parser.parse_args(args)
 
-    setup_logging(
-        args.log_conf, args.log_filename, args.error_email, args.log_level, "crmprtd"
-    )
+        setup_logging(
+            args.log_conf,
+            args.log_filename,
+            args.error_email,
+            args.log_level,
+            "crmprtd",
+        )
 
-    utc = pytz.utc
+        utc = pytz.utc
 
-    args.start_date = utc.localize(
-        verify_date(args.start_date, datetime.min, "start date")
-    )
-    args.end_date = utc.localize(verify_date(args.end_date, datetime.max, "end date"))
+        args.start_date = utc.localize(
+            verify_date(args.start_date, datetime.min, "start date")
+        )
+        args.end_date = utc.localize(
+            verify_date(args.end_date, datetime.max, "end date")
+        )
 
-    process(
-        connection_string=args.connection_string,
-        sample_size=args.sample_size,
-        network=args.network,
-        start_date=args.start_date,
-        end_date=args.end_date,
-        is_diagnostic=args.diag,
-        do_infer=args.infer,
-    )
+        process(
+            connection_string=args.connection_string,
+            sample_size=args.sample_size,
+            network=args.network,
+            start_date=args.start_date,
+            end_date=args.end_date,
+            is_diagnostic=args.diag,
+            do_infer=args.infer,
+        )
+    except Exception:
+        log.exception("Unhandled exception during 'process'")
 
 
 if __name__ == "__main__":

--- a/scripts/infill_all.py
+++ b/scripts/infill_all.py
@@ -13,7 +13,7 @@ details (for MoTI and WMB) and a database connection. Optionally you
 can configure the loggging, and select a subset of available networks
 to infill.
 """
-
+import logging
 from argparse import ArgumentParser
 import datetime
 import itertools
@@ -24,73 +24,79 @@ from crmprtd import add_logging_args, setup_logging, add_version_arg, get_versio
 from crmprtd.infill import infill
 
 
+log = logging.getLogger(__name__)
+
+
 def main(args=None):
-    desc = globals()["__doc__"]
-    parser = ArgumentParser(description=desc)
-    add_version_arg(parser)
-    parser.add_argument(
-        "-S",
-        "--start_time",
-        help=(
-            "Alternate time to use for downloading "
-            "(interpreted with "
-            "strptime(format='Y/m/d H:M:S')."
-        ),
-    )
-    parser.add_argument(
-        "-E",
-        "--end_time",
-        help=(
-            "Alternate time to use for downloading "
-            "(interpreted with "
-            "strptime(format='Y/m/d H:M:S')."
-        ),
-    )
-    parser.add_argument(
-        "-a",
-        "--auth_fname",
-        help="Yaml file with plaintext usernames/passwords. "
-        "For simplicity the auth keys are *not* "
-        "configurable (unlike the download scripts. The "
-        "supplied file must contain keys with names "
-        "'moti', 'moti2' and 'wmb' if you want to infill "
-        "those networks.",
-    )
-    parser.add_argument(
-        "-c", "--connection_string", help="PostgreSQL connection string"
-    )
-    parser.add_argument(
-        "-N",
-        "--networks",
-        nargs="*",
-        default="crd ec moti wamr wmb ec_swob",
-        help="Set of networks for which to infill",
-    )
+    try:
+        desc = globals()["__doc__"]
+        parser = ArgumentParser(description=desc)
+        add_version_arg(parser)
+        parser.add_argument(
+            "-S",
+            "--start_time",
+            help=(
+                "Alternate time to use for downloading "
+                "(interpreted with "
+                "strptime(format='Y/m/d H:M:S')."
+            ),
+        )
+        parser.add_argument(
+            "-E",
+            "--end_time",
+            help=(
+                "Alternate time to use for downloading "
+                "(interpreted with "
+                "strptime(format='Y/m/d H:M:S')."
+            ),
+        )
+        parser.add_argument(
+            "-a",
+            "--auth_fname",
+            help="Yaml file with plaintext usernames/passwords. "
+            "For simplicity the auth keys are *not* "
+            "configurable (unlike the download scripts. The "
+            "supplied file must contain keys with names "
+            "'moti', 'moti2' and 'wmb' if you want to infill "
+            "those networks.",
+        )
+        parser.add_argument(
+            "-c", "--connection_string", help="PostgreSQL connection string"
+        )
+        parser.add_argument(
+            "-N",
+            "--networks",
+            nargs="*",
+            default="crd ec moti wamr wmb ec_swob",
+            help="Set of networks for which to infill",
+        )
 
-    parser = add_logging_args(parser)
-    args = parser.parse_args(args)
+        parser = add_logging_args(parser)
+        args = parser.parse_args(args)
 
-    if args.version:
-        print(get_version())
-        return
+        if args.version:
+            print(get_version())
+            return
 
-    log_args = [
-        args.log_conf,
-        args.log_filename,
-        args.error_email,
-        args.log_level,
-        "infill_all",
-    ]
-    setup_logging(*log_args)
+        log_args = [
+            args.log_conf,
+            args.log_filename,
+            args.error_email,
+            args.log_level,
+            "infill_all",
+        ]
+        setup_logging(*log_args)
 
-    fmt = "%Y/%m/%d %H:%M:%S"
-    s = datetime.datetime.strptime(args.start_time, fmt).astimezone(tzlocal())
-    e = datetime.datetime.strptime(args.end_time, fmt).astimezone(tzlocal())
+        fmt = "%Y/%m/%d %H:%M:%S"
+        s = datetime.datetime.strptime(args.start_time, fmt).astimezone(tzlocal())
+        e = datetime.datetime.strptime(args.end_time, fmt).astimezone(tzlocal())
 
-    log_args = [(x, y) for (x, y) in zip(["-L", "-l", "-m", "-o"], log_args) if y]
-    log_args = list(itertools.chain(*log_args))
+        log_args = [(x, y) for (x, y) in zip(["-L", "-l", "-m", "-o"], log_args) if y]
+        log_args = list(itertools.chain(*log_args))
 
-    infill(args.networks, s, e, args.auth_fname, args.connection_string, log_args)
+        infill(args.networks, s, e, args.auth_fname, args.connection_string, log_args)
+    except Exception:
+        log.exception("Unhandled exception during 'infill_all'")
 
 
 if __name__ == "__main__":

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import datetime
 
@@ -45,11 +47,12 @@ def test_verify_date(datestring, default):
 
 
 @pytest.mark.parametrize(("datestring"), (("not-a-datestring"), (None)))
-def test_verify_date_exception(datestring):
+def test_verify_date_exception(caplog, datestring):
+    caplog.set_level(logging.WARNING)
     default = datetime.datetime.now()
     warning = (
         f"Parameter  '{datestring}' is undefined or unparseable. Using the "
         f"default '{default:%Y-%m-%d %H:%M:%S}'"
     )
-    with pytest.warns(UserWarning, match=warning):
-        assert verify_date(datestring, default, "") == default
+    assert verify_date(datestring, default, "") == default
+    assert warning in caplog.text


### PR DESCRIPTION
Resolves #157
 
Tested with an invalid connection string for the database: Error appropriately logged. 

When the CLI interface is invoked incorrectly (e.g., incorrect arguments to script), it will exit with error info, which is the [default behaviour of argparse](https://docs.python.org/3/library/argparse.html#exit-on-error). It seems unwieldy to override this an log these to the logger, but it can be done (see same link). Also it isn't available in Python <= 3.8, which is the highest version of Python we have currently available on the crmprtd server.