### PR TITLE
Filter out redundant observations before trying to insert (focus on network bc_hydro)

### DIFF
--- a/crmprtd/data/publication_lags.yaml
+++ b/crmprtd/data/publication_lags.yaml
@@ -1,0 +1,9 @@
+# This configuration is a set of key-value pairs that configure publication
+# lags for the processing step (`process.py`).
+#
+# The key is the network name. The value is the default publication lag in days,
+# if one is not specified by the user.
+#
+# Any network not configured here does not use publication lags.
+
+bc_hydro: 14

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -127,7 +127,7 @@ def insert_single_obs(sesh, obs):
 def single_insert_strategy(sesh, observations):
     dbm = DBMetrics(0, 0, 0)
     for obs in observations:
-        insert_single_obs(sesh, obs)
+        dbm += insert_single_obs(sesh, obs)
     return dbm
 
 
@@ -160,7 +160,7 @@ def bisect_insert_strategy(sesh, observations):
     if len(observations) < 1:
         return DBMetrics(0, 0, 0)
     elif len(observations) == 1:
-        insert_single_obs(sesh, observations[0])
+        return insert_single_obs(sesh, observations[0])
     # The happy case: add everything at once
     else:
         try:

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -72,8 +72,9 @@ def add_process_args(parser):  # pragma: no cover
             "For networks where the default start date is determined from "
             "the latest observation date in the database, this parameter "
             "defines the number of days that should be subtracted from the "
-            "latest observation date to set the start date. Currently this"
-            "parameter is used only for network 'bc_hydro'."
+            "latest observation date to set the start date. Publication lag "
+            "is used only for certain networks; they are configured in the "
+            "internal file 'crmprtd/data/publication_lags.yaml'."
         ),
     )
     parser.add_argument(
@@ -149,8 +150,8 @@ def process(
         )
         log.info(f"Latest obs time for network {network}: {latest_obs_time}")
         if latest_obs_time is not None:
-            # Obs.time is implicitly UTC, but we need to apply that info to the
-            # unlocalized value we get from the database.
+            # Obs.time is implicitly UTC but is unlocalized in the database.
+            # We have to make that explicit. Then subtract publication lag.
             start_date = pytz.utc.localize(latest_obs_time) - timedelta(
                 days=(publication_lag or publication_lags[network])
             )

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -173,7 +173,7 @@ def process(
     # It is probably better to use a dict for this to preserve order.
     # See https://stackoverflow.com/a/9792680
     rows = {row for row in norm_mod.normalize(download_stream)}
-    log.debug(f"Found {len(rows)} rows.")
+    log.info(f"Normalized {len(rows)} rows.")
     log.info("Normalize: done")
 
     # Optionally infer variables and stations/histories.

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -5,7 +5,7 @@ from importlib import import_module
 from itertools import tee
 import logging
 from argparse import ArgumentParser
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -109,7 +109,7 @@ def process(
             # For the sake of safety, assume that some new values include values
             # for observations dated not just in the past week, but a week before
             # as well. Is this actually possible?
-            "bc_hydro": datetime.timedelta(days=14),
+            "bc_hydro": timedelta(days=14),
         }
 
     if network == "_test":

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -150,6 +150,10 @@ def process(
     # At present, this is impossible, but hey, it's cheap insurance.
     if end_date is None:
         start_date = datetime.max
+    log.info(
+        f"Final time filter parameters: "
+        f"start_date = {start_date}, end_date = {end_date}"
+    )
 
     # Get the normalizer for the specified network.
     download_stream = sys.stdin.buffer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "crmprtd"
-version = "4.3.1.dev1"
+version = "4.3.1.dev2"
 description = "Utility to download near real time weather data and insert it into PCIC's database"
 license = "GPL-3.0-only"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "crmprtd"
-version = "4.3.1.dev0"
+version = "4.3.1.dev1"
 description = "Utility to download near real time weather data and insert it into PCIC's database"
 license = "GPL-3.0-only"
 authors = [

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -11,7 +11,7 @@ from crmprtd.insert import (
     get_sample_indices,
     obs_exist,
     contains_all_duplicates,
-    single_insert_obs,
+    single_insert_strategy,
 )
 
 
@@ -149,7 +149,7 @@ def test_contains_all_duplicates_all_dup(test_session):
 
 def test_single_insert_obs(test_session):
     ob = [Obs(history_id=20, vars_id=2, time=datetime.now(), datum=10)]
-    dbm = single_insert_obs(test_session, ob)
+    dbm = single_insert_strategy(test_session, ob)
     assert dbm.successes == 1
 
     q = test_session.query(Obs)
@@ -165,5 +165,5 @@ def test_single_insert_obs_not_unique(test_session):
             datum=10,
         )
     ]
-    dbm = single_insert_obs(test_session, ob)
+    dbm = single_insert_strategy(test_session, ob)
     assert dbm.skips == 1

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -11,6 +11,7 @@ from crmprtd.insert import (
     get_sample_indices,
     obs_exist,
     contains_all_duplicates,
+    contains_all_duplicates,
     single_insert_strategy,
 )
 


### PR DESCRIPTION
This PR does two things:
- Adds time-filtering for network bc_hydro:
  - When start time argument is not specified, now uses a default value for start time that is computed as (latest observation time for bc_hydro) - (publication lag).
  - See #163 for details on publication lag.
  - Publication lags are configured from a data file (`crmprtd/data/publication_lags.yaml`) and can be overridden by an argument.
- Eliminates a step from, and, I believe, possibly speeds up single-observation insertions.
  - Originally, there were two separately launched queries: "does this observation already exist; if not, insert it". 
  - Replaces it with the same one-step method used for bulk insertions, which handles the case that the uniqueness constraint rejects an already-existing query. 
  - This also DRYs up the insert code.
  - UPDATE: A test run on crmprtd today (May 1) shows that insertions for single observations are taking an average of ~500 ms, which is much faster than the observed time of > 3 s for single insertions in the previous version. Since both strategies, single-insert and bisection, share the same code, this demonstrates that we have improved the speed for single-insert strategy significantly.

Resolves #163 