### PR TITLE
Improve align and insert phase performance

### DIFF
--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -129,6 +129,9 @@ def add_logging_args(parser):
     return parser
 
 
+# TODO: What is a "common" argument and what are phase-specific arguments needs to be
+#   reviewed. There are several arguments specific to the process phase here; others
+#   specific to it are in add_process_arguments.
 def common_script_arguments(parser):  # pragma: no cover
     parser.add_argument(
         "-c", "--connection_string", help="PostgreSQL connection string"
@@ -180,7 +183,7 @@ def common_script_arguments(parser):  # pragma: no cover
         default=50,
         help="Number of samples to be taken from observations "
         "when searching for duplicates "
-        "to determine which insertion strategy to use",
+        "to determine how to handle bisection strategy",
     )
     return parser
 

--- a/crmprtd/__init__.py
+++ b/crmprtd/__init__.py
@@ -181,9 +181,10 @@ def common_script_arguments(parser):  # pragma: no cover
         "--sample_size",
         type=int,
         default=50,
-        help="Number of samples to be taken from observations "
-        "when searching for duplicates "
-        "to determine how to handle bisection strategy",
+        help=(
+            "Number of samples to be taken from observations when searching for "
+            "duplicates to determine how to handle ADAPTIVE insertion strategy"
+        ),
     )
     return parser
 

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -442,12 +442,8 @@ def align(sesh, row, diagnostic=False):
         )
         return None
 
-    # To allow the use of the PostgreSQL dialect-specific `insert` function, we return a
-    # dict with the relevant key-value mapping. This may need to be converted to an Obs
-    # object, or not, depending on how it is used.
-    return {
-        "history_id": history.id,
-        "obs_time": row.time,
-        "datum": datum,
-        "vars_id": var_id,
-    }
+    # Create Obs object.
+    # Note: We are very specifically creating the Obs object here using the ids
+    # to avoid SQLAlchemy adding this object to the session as part of its
+    # cascading backref behaviour https://goo.gl/Lchhv6
+    return Obs(history_id=history.id, time=row.time, datum=datum, vars_id=var_id)

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -446,4 +446,13 @@ def align(sesh, row, diagnostic=False):
     # Note: We are very specifically creating the Obs object here using the ids
     # to avoid SQLAlchemy adding this object to the session as part of its
     # cascading backref behaviour https://goo.gl/Lchhv6
-    return Obs(history_id=history.id, time=row.time, datum=datum, vars_id=var_id)
+    # return Obs(history_id=history.id, time=row.time, datum=datum, vars_id=var_id)
+
+    # To allow the use of the PostgreSQL dialect-specific `insert` function, we return a
+    # dict with the relevant key-value mapping. And native table key names.
+    return {
+        "history_id": history.id,
+        "obs_time": row.time,
+        "datum": datum,
+        "vars_id": var_id,
+    }

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -67,7 +67,7 @@ def cached_function(attrs):
             key = (args) + tuple(kwargs.items())
             if key not in cache:
                 obj = f(sesh, *args, **kwargs)
-                log.info(f"Cache miss: {f.__name__} {key} -> {repr(obj)}")
+                log.debug(f"Cache miss: {f.__name__} {key} -> {repr(obj)}")
                 cache[key] = obj and SimpleNamespace(
                     **{attr: getattr(obj, attr) for attr in attrs}
                 )

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -42,9 +42,9 @@ for def_ in (
 
 
 def cached_function(attrs):
-    """A context manager that can be used to cache database results
+    """A decorator factory that can be used to cache database results
 
-        Neither database sessions (i.e. the sesh parameter of each wrapped
+    Neither database sessions (i.e. the sesh parameter of each wrapped
     function) nor SQLAlchemy mapped objects (the results of queries) are
     cachable or reusable. Therefore one cannot memoize database query
     functions using builtin things like the lrucache.
@@ -55,8 +55,8 @@ def cached_function(attrs):
     and c) accepting as a parameter a list of attributes to retrieve and
     store in the cache result.
 
-        args (except sesh) and kwargs to the wrapped function are used as
-        the cache key, and results are the parametrized object attributes.
+    args (except sesh) and kwargs to the wrapped function are used as
+    the cache key, and results are the parametrized object attributes.
     """
 
     def wrapper(f):
@@ -67,9 +67,8 @@ def cached_function(attrs):
             key = (args) + tuple(kwargs.items())
             if key not in cache:
                 obj = f(sesh, *args, **kwargs)
-                if not obj:
-                    return None
-                cache[key] = SimpleNamespace(
+                log.info(f"Cache miss: {f.__name__} {key} -> {repr(obj)}")
+                cache[key] = obj and SimpleNamespace(
                     **{attr: getattr(obj, attr) for attr in attrs}
                 )
             return cache[key]

--- a/crmprtd/align.py
+++ b/crmprtd/align.py
@@ -442,14 +442,9 @@ def align(sesh, row, diagnostic=False):
         )
         return None
 
-    # Create Obs object.
-    # Note: We are very specifically creating the Obs object here using the ids
-    # to avoid SQLAlchemy adding this object to the session as part of its
-    # cascading backref behaviour https://goo.gl/Lchhv6
-    # return Obs(history_id=history.id, time=row.time, datum=datum, vars_id=var_id)
-
     # To allow the use of the PostgreSQL dialect-specific `insert` function, we return a
-    # dict with the relevant key-value mapping. And native table key names.
+    # dict with the relevant key-value mapping. This may need to be converted to an Obs
+    # object, or not, depending on how it is used.
     return {
         "history_id": history.id,
         "obs_time": row.time,

--- a/crmprtd/constants.py
+++ b/crmprtd/constants.py
@@ -1,3 +1,3 @@
 from enum import Enum
 
-InsertStrategy = Enum("InsertStrategy", ["BULK", "BISECTION"])
+InsertStrategy = Enum("InsertStrategy", ["BULK", "SINGLE", "CHUNK_BISECT", "ADAPTIVE"])

--- a/crmprtd/constants.py
+++ b/crmprtd/constants.py
@@ -1,0 +1,3 @@
+from enum import Enum
+
+InsertStrategy = Enum("InsertStrategy", ["BULK", "OTHER"])

--- a/crmprtd/constants.py
+++ b/crmprtd/constants.py
@@ -1,3 +1,3 @@
 from enum import Enum
 
-InsertStrategy = Enum("InsertStrategy", ["BULK", "OTHER"])
+InsertStrategy = Enum("InsertStrategy", ["BULK", "BISECTION"])

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -127,7 +127,7 @@ def insert_single_obs(sesh, obs):
 def single_insert_strategy(sesh, observations):
     dbm = DBMetrics(0, 0, 0)
     for obs in observations:
-        insert_single_obs(sesh, obs)
+        dbm += insert_single_obs(sesh, obs)
     return dbm
 
 
@@ -160,7 +160,7 @@ def bisect_insert_strategy(sesh, observations):
     if len(observations) < 1:
         return DBMetrics(0, 0, 0)
     elif len(observations) == 1:
-        insert_single_obs(sesh, observations[0])
+        return insert_single_obs(sesh, observations[0])
     # The happy case: add everything at once
     else:
         try:

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -271,13 +271,8 @@ def insert_bulk_obs(sesh, observations):
         # exception.
         log.exception("Unexpected error during bulk insertion")
         return DBMetrics(0, 0, num_to_insert)
-    else:
-        num_inserted = len(result)
-        log.info(
-            f"Successfully inserted observations: {num_inserted}",
-            extra={"num_obs": num_inserted},
-        )
     sesh.commit()
+    num_inserted = len(result)
     return DBMetrics(num_inserted, num_to_insert - num_inserted, 0)
 
 
@@ -295,7 +290,9 @@ def bulk_insert_strategy(sesh, observations, chunk_size=1000):
     log.info("Using Bulk Insert Strategy")
     dbm = DBMetrics(0, 0, 0)
     for chunk in fixed_length_chunks(observations, chunk_size=chunk_size):
-        dbm += insert_bulk_obs(sesh, chunk)
+        chunk_dbm = insert_bulk_obs(sesh, chunk)
+        log.info(f"Bulk insert progress: {dbm.successes} inserted, {dbm.skips} skipped")
+        dbm += chunk_dbm
     return dbm
 
 

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -245,10 +245,10 @@ def insert_bulk_obs(sesh, observations):
                 .on_conflict_do_nothing()
                 .returning(Obs.id)
             ).fetchall()
-    except DBAPIError as e:
+    except DBAPIError:
         # Something really unanticipated happened. Duplicate rows do not trigger an
         # exception.
-        log.warning(f"Unexpected error during bulk insertion: {e}")
+        log.exception("Unexpected error during bulk insertion")
         return DBMetrics(0, 0, num_to_insert)
     else:
         num_inserted = len(result)

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -291,8 +291,12 @@ def bulk_insert_strategy(sesh, observations, chunk_size=1000):
     dbm = DBMetrics(0, 0, 0)
     for chunk in fixed_length_chunks(observations, chunk_size=chunk_size):
         chunk_dbm = insert_bulk_obs(sesh, chunk)
-        log.info(f"Bulk insert progress: {dbm.successes} inserted, {dbm.skips} skipped")
         dbm += chunk_dbm
+        log.info(
+            f"Bulk insert progress: "
+            f"{dbm.successes} inserted, {dbm.skips} skipped, {dbm.failures} failed"
+        )
+    log.info(f"Successfully inserted observations: {dbm.successes}")
     return dbm
 
 

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -94,7 +94,6 @@ def get_sample_indices(num_obs, sample_size):
     return random.sample(range(num_obs), sample_size)
 
 
-# TODO: Remove, no longer used
 def obs_exist(sesh, history_id, vars_id, time):
     q = sesh.query(Obs).filter(
         and_(Obs.history_id == history_id, Obs.vars_id == vars_id, Obs.time == time)

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -277,12 +277,12 @@ def insert(
     sesh.commit()
 
     with Timer() as tmr:
-        if strategy == InsertStrategy.BULK:
+        if strategy is InsertStrategy.BULK:
             log.info("Using Bulk Insert Strategy")
             dbm = DBMetrics(0, 0, 0)
             for chunk in fixed_length_chunks(observations, chunk_size=bulk_chunk_size):
                 dbm += bulk_insert_strategy(sesh, chunk)
-        elif strategy == InsertStrategy.BISECTION:
+        elif strategy is InsertStrategy.BISECTION:
             # Output of align is a list of dicts. These must be converted to Obs
             # objects for the consumption of BISECTION strategy. Because the ORM
             # doesn't use the same column names as the native table, this is tedious.

--- a/crmprtd/insert.py
+++ b/crmprtd/insert.py
@@ -311,12 +311,12 @@ def insert(
     Insert a collection of observations.
 
     :param sesh: SQLAlchemy database session
-    :param observations: For BULK insert strategy, list of dicts containing Obs rows
-        to insert. For OTHER insert strategy, list of Obs objects to insert.
-    :param strategy: Insert strategy. BULK is currently fastest.
+    :param observations: List of Obs objects to insert.
+    :param strategy: (InsertStrategy) Insert strategy. InsertStrategy.BULK is
+        currently fastest.
     :param bulk_chunk_size: Fixed chunk size for BULK insert strategy.
     :param sample_size: Size of sample of observations to use to test for duplicates
-        for BISECTION insert strategy.
+        for ADAPTIVE insert strategy.
     :return: dict with information about insertions
     """
 

--- a/crmprtd/more_itertools.py
+++ b/crmprtd/more_itertools.py
@@ -1,0 +1,14 @@
+"""
+Some additional iteration tools
+"""
+from itertools import islice, cycle
+
+
+def take(n, iterable):
+    """Yield the first n values of an iterable"""
+    return islice(iterable, n)
+
+
+def cycles(cycle_length, n):
+    """Yield the first n values of a cycling (repeating) range of length cycle_length"""
+    return take(n, cycle(range(cycle_length)))

--- a/crmprtd/more_itertools.py
+++ b/crmprtd/more_itertools.py
@@ -12,3 +12,44 @@ def take(n, iterable):
 def cycles(cycle_length, n):
     """Yield the first n values of a cycling (repeating) range of length cycle_length"""
     return take(n, cycle(range(cycle_length)))
+
+
+def tap(f, iterable):
+    """Return a generator that calls function f on each item, then yields the item."""
+    for item in iterable:
+        f(item)
+        yield item
+
+
+def log_progress(when=(10,), message="progress: {count}", log=None):
+    """
+    Return a function that logs a message periodically. This function is typically used
+    to log progress updates during a long iteration, when such an update would be
+    too bulky or intrusive if logged on every iteration.
+
+    The function returned accepts an optional keyword argument, `item`, that can be
+    used to pass in other information, e.g., the current iteration item. This is its
+    typical usage, but it could be used differently.
+
+    The function maintains a count of calls to it.
+
+    A message is logged according to the argument `when`, which is either a single
+    integer or an iterable of integers. (A single integer is converted to a length-1
+    tuple.) A message is logged when the call count is equal to any of the integers in
+    `when` or when it is a multiple of the last integer in `when`. This enables
+    messages to be logged more frequently in the early parts of an iteration and less
+    frequently in the later parts.
+    """
+    count = 0
+    when = tuple(when)
+    front, last = when[0 : len(when) - 1], when[len(when) - 1]
+
+    def f(item=None):
+        if log is None:
+            return
+        nonlocal count
+        count += 1
+        if count in front or count % last == 0:
+            log(message.format(count=count, item=item))
+
+    return f

--- a/crmprtd/more_itertools.py
+++ b/crmprtd/more_itertools.py
@@ -24,8 +24,8 @@ def tap(f, iterable):
 def log_progress(when=(10,), message="progress: {count}", log=None):
     """
     Return a function that logs a message periodically. This function is typically used
-    to log progress updates during a long iteration, when such an update would be
-    too bulky or intrusive if logged on every iteration.
+    to log progress updates during a long iteration, when such updates would be too
+    bulky or intrusive if logged on every iteration.
 
     The function returned accepts an optional keyword argument, `item`, that can be
     used to pass in other information, e.g., the current iteration item. This is its
@@ -39,10 +39,20 @@ def log_progress(when=(10,), message="progress: {count}", log=None):
     `when` or when it is a multiple of the last integer in `when`. This enables
     messages to be logged more frequently in the early parts of an iteration and less
     frequently in the later parts.
+
+    The message is defined by argument `message`, which is a template string that is
+    formatted with arguments `count` (function call count) and `item` (function
+    argument) when a message is logged.
+
+    The logger is given by the argument `log`, which is typically a Python logger
+    function.
+
+    Interesting that the explanation is 3x as long as the code.
     """
     count = 0
     when = tuple(when)
     front, last = when[0 : len(when) - 1], when[len(when) - 1]
+    log(f"log_progress: when={when}, front={front}, last={last}")
 
     def f(item=None):
         if log is None:

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -10,8 +10,6 @@ from datetime import datetime
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from pycds import Obs, Variable, Network
-
 from crmprtd.constants import InsertStrategy
 from crmprtd.align import align
 from crmprtd.insert import insert

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -77,9 +77,17 @@ def add_process_args(parser):  # pragma: no cover
         help=(
             "Strategy to use for inserting observations. The default BULK strategy "
             "handles duplicate observation conflicts inside the database; it is "
-            "fastest and is the recommended strategy. The BISECTION strategy handles "
-            "duplicate observation conflicts in the code and is considerably slower. "
-            "It is preserved mainly for experimentation and comparison.",
+            "fastest and is the recommended strategy. The other strategies handle "
+            "duplicate observation conflicts outside the database (that is, in this "
+            "client), and are considerably slower. They are preserved mainly for "
+            "experimentation and comparison. The SINGLE strategy tries inserting the "
+            "observations one at a time. The CHUNK_BISECT strategy tries inserting the "
+            "observations in fairly large sized chunks, and seeks small sized "
+            "sub-chunks if any given chunk fails (because it contains a duplicate). "
+            "The ADAPTIVE strategy chooses between SINGLE or CHUNK_BISECT based on a "
+            "small randomly selected sample of the observations to be inserted; if all "
+            "the observations in this sample are duplicates, it uses SINGLE; "
+            "if not, it uses CHUNK_BISECT."
         ),
     )
     parser.add_argument(

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -216,9 +216,9 @@ def main(args=None):
 
         utc = pytz.utc
 
-        # Value of None for start_date is meaningful: it means, for some networks,
-        # determine from database.
-        args.start_date = utc.localize(verify_date(args.start_date, None, "start date"))
+        args.start_date = utc.localize(
+            verify_date(args.start_date, datetime.min, "start date")
+        )
         args.end_date = utc.localize(
             verify_date(args.end_date, datetime.max, "end date")
         )

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -132,7 +132,7 @@ def process(
     # The normalizer returns a generator that yields `Row`s. Convert to a set of `Row`s.
     # It is probably better to use a dict for this to preserve order.
     # See https://stackoverflow.com/a/9792680
-    # Note: Normalization is important. In some datasets, there is a lot of repetition
+    # Note: Deduplication is important. In some datasets, there is a lot of repetition
     # (factor of 6 in the case of BCH).
     raw_rows = tuple(norm_mod.normalize(download_stream))
     log.info(f"Normalized {len(raw_rows)} rows")

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -57,14 +57,12 @@ def add_process_args(parser):  # pragma: no cover
         "--start_date",
         help="Optional start time to use for processing "
         "(interpreted with dateutil.parser.parse).",
-        default=str(datetime.min),
     )
     parser.add_argument(
         "-E",
         "--end_date",
         help="Optional end time to use for processing "
         "(interpreted with dateutil.parser.parse).",
-        default=str(datetime.max),
     )
     parser.add_argument(
         "-I",
@@ -115,9 +113,10 @@ def process(
     download_stream = sys.stdin.buffer
     norm_mod = get_normalization_module(network)
 
-    # The normalizer returns a generator that yields `Row`s. Convert to a set of Rows.
     log.info("Normalize: start")
-
+    # The normalizer returns a generator that yields `Row`s. Convert to a set of Rows.
+    # It is probably better to use a dict for this to preserve order.
+    # See https://stackoverflow.com/a/9792680
     rows = {row for row in norm_mod.normalize(download_stream)}
     log.debug(f"Found {len(rows)} rows.")
     log.info("Normalize: done")
@@ -217,9 +216,9 @@ def main(args=None):
 
         utc = pytz.utc
 
-        args.start_date = utc.localize(
-            verify_date(args.start_date, datetime.min, "start date")
-        )
+        # Value of None for start_date is meaningful: it means, for some networks,
+        # determine from database.
+        args.start_date = utc.localize(verify_date(args.start_date, None, "start date"))
         args.end_date = utc.localize(
             verify_date(args.end_date, datetime.max, "end date")
         )

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -173,7 +173,9 @@ def process(
             None,
             tap(
                 log_progress(
-                    (1, 2, 10, 100, 1000, 10000), "align progress: {count}", log.info
+                    (1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 5000),
+                    "align progress: {count}",
+                    log.info,
                 ),
                 (
                     align(sesh, row, is_diagnostic)

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -16,7 +16,7 @@ from crmprtd.insert import insert
 from crmprtd.download_utils import verify_date
 from crmprtd.infer import infer
 from crmprtd import add_version_arg, add_logging_args, setup_logging, NETWORKS
-
+from crmprtd.more_itertools import tap, log_progress
 
 log = logging.getLogger(__name__)
 
@@ -171,10 +171,15 @@ def process(
         # in this case possible None values returned by align.
         filter(
             None,
-            (
-                align(sesh, row, is_diagnostic)
-                for row in rows
-                if start_date <= row.time <= end_date
+            tap(
+                log_progress(
+                    (1, 2, 10, 100, 1000, 10000), "align progress: {count}", log.info
+                ),
+                (
+                    align(sesh, row, is_diagnostic)
+                    for row in rows
+                    if start_date <= row.time <= end_date
+                ),
             ),
         )
     )

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -76,6 +76,19 @@ def add_process_args(parser):  # pragma: no cover
         "determines what metadata insertions could be made based"
         "on the observed data available",
     )
+    parser.add_argument(
+        "-R",
+        "--insert_strategy",
+        choices=[s.name for s in InsertStrategy],
+        default="BULK",
+        help=(
+            "Strategy to use for inserting observations. The default BULK strategy "
+            "handles duplicate observation conflicts inside the database; it is "
+            "fastest and is the recommended strategy. The BISECTION strategy handles "
+            "duplicate observation conflicts in the code and is considerably slower. "
+            "It is preserved mainly for experimentation and comparison.",
+        ),
+    )
     return parser
 
 
@@ -241,6 +254,7 @@ def main(args=None):
             end_date=args.end_date,
             is_diagnostic=args.diag,
             do_infer=args.infer,
+            insert_strategy=InsertStrategy[args.insert_strategy],
         )
     except Exception:
         log.exception("Unhandled exception during 'process'")

--- a/crmprtd/process.py
+++ b/crmprtd/process.py
@@ -118,7 +118,7 @@ def process(
     # It is probably better to use a dict for this to preserve order.
     # See https://stackoverflow.com/a/9792680
     rows = {row for row in norm_mod.normalize(download_stream)}
-    log.debug(f"Found {len(rows)} rows.")
+    log.info(f"Normalized {len(rows)} rows.")
     log.info("Normalize: done")
 
     engine = create_engine(connection_string)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "crmprtd"
-version = "4.3.1.dev0"
+version = "4.3.1.dev3"
 description = "Utility to download near real time weather data and insert it into PCIC's database"
 license = "GPL-3.0-only"
 authors = [

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -240,10 +240,10 @@ def test_align_successes(
     test_session, obs_tuple, expected_hid, expected_time, expeceted_vid, expected_datum
 ):
     ob = align(test_session, obs_tuple)
-    assert ob["history_id"] == expected_hid
-    assert ob["obs_time"] == expected_time
-    assert ob["vars_id"] == expeceted_vid
-    assert ob["datum"] == expected_datum
+    assert ob.history_id == expected_hid
+    assert ob.time == expected_time
+    assert ob.vars_id == expeceted_vid
+    assert ob.datum == expected_datum
 
 
 @pytest.mark.parametrize(

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -240,10 +240,10 @@ def test_align_successes(
     test_session, obs_tuple, expected_hid, expected_time, expeceted_vid, expected_datum
 ):
     ob = align(test_session, obs_tuple)
-    assert ob.history_id == expected_hid
-    assert ob.time == expected_time
-    assert ob.vars_id == expeceted_vid
-    assert ob.datum == expected_datum
+    assert ob["history_id"] == expected_hid
+    assert ob["obs_time"] == expected_time
+    assert ob["vars_id"] == expeceted_vid
+    assert ob["datum"] == expected_datum
 
 
 @pytest.mark.parametrize(

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -11,7 +11,7 @@ from crmprtd.insert import (
     get_sample_indices,
     obs_exist,
     contains_all_duplicates,
-    single_insert_obs,
+    single_insert_strategy,
 )
 
 
@@ -149,7 +149,7 @@ def test_contains_all_duplicates_all_dup(test_session):
 
 def test_single_insert_obs(test_session):
     ob = [Obs(history_id=20, vars_id=2, time=datetime.now(), datum=10)]
-    dbm = single_insert_obs(test_session, ob)
+    dbm = single_insert_strategy(test_session, ob)
     assert dbm.successes == 1
 
     q = test_session.query(Obs)
@@ -165,5 +165,5 @@ def test_single_insert_obs_not_unique(test_session):
             datum=10,
         )
     ]
-    dbm = single_insert_obs(test_session, ob)
+    dbm = single_insert_strategy(test_session, ob)
     assert dbm.skips == 1

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -99,9 +99,9 @@ def test_bisect_insert_strategy(test_session, label, days, expected):
 
     obs = [
         Obs(
-            history=history,
+            history_id=history.id,
             datum=2.5,
-            variable=variable,
+            vars_id=variable.id,
             time=datetime(2017, 8, 6, 0, tzinfo=pytz.utc) + timedelta(days=d),
         )
         for d in days

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -11,6 +11,7 @@ from crmprtd.insert import (
     get_sample_indices,
     obs_exist,
     contains_all_duplicates,
+    contains_all_duplicates,
     single_insert_strategy,
 )
 

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -59,12 +59,12 @@ def test_bulk_insert_strategy(test_session, label, days, expected):
     variable = history.station.network.variables[0]
 
     obs = [
-        {
-            "history_id": history.id,
-            "datum": 2.5,
-            "vars_id": variable.id,
-            "obs_time": datetime(2017, 8, 6, 0, tzinfo=pytz.utc) + timedelta(days=d),
-        }
+        Obs(
+            history_id=history.id,
+            datum=2.5,
+            vars_id=variable.id,
+            time=datetime(2017, 8, 6, 0, tzinfo=pytz.utc) + timedelta(days=d),
+        )
         for d in days
     ]
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -84,7 +84,7 @@ def test_process_by_date(
 
     # Restrict the logging to just what is important to this test.
     caplog.set_level(logging.WARNING, "sqlalchemy.engine")
-    caplog.set_level(logging.DEBUG, "crmprtd")
+    caplog.set_level(logging.INFO, "crmprtd")
 
     utc = pytz.utc
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -9,6 +9,8 @@ from pkg_resources import resource_filename
 from sqlalchemy.exc import IntegrityError
 
 from pycds import Network, History, Variable, Obs
+
+from crmprtd.constants import InsertStrategy
 from crmprtd.download_utils import verify_date
 
 # Must import the module, not objects from it, so we can mock the objects.
@@ -56,6 +58,7 @@ def num_observations_in_db(session):
     return session.query(Obs).count()
 
 
+@pytest.mark.parametrize("insert_strategy", InsertStrategy)
 @pytest.mark.parametrize(
     # There are 2510 observations in the test data file, all dated 2022-06-17.
     # Of these, 2360 are unique. Those should be inserted; the 150 duplicates should
@@ -70,7 +73,13 @@ def num_observations_in_db(session):
 )
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_process_by_date(
-    start_date, end_date, expected_num_inserts, monkeypatch, caplog, crmp_session
+    insert_strategy,
+    start_date,
+    end_date,
+    expected_num_inserts,
+    monkeypatch,
+    caplog,
+    crmp_session,
 ):
     # align has several functions that reach out to the database and
     # subsequently cache results While this speeds up align
@@ -140,6 +149,7 @@ def test_process_by_date(
         end_date=end_date,
         is_diagnostic=False,
         do_infer=True,
+        insert_strategy=insert_strategy,
     )
 
     num_obs_in_db_after = num_observations_in_db(crmp_session)


### PR DESCRIPTION
Resolves #165 

This PR:
- Adds a BULK insert strategy that uses the PG `INSERT .... ON CONFLICT DO NOTHING` feature to insert large numbers of rows into the Obs table, some of which may violate the unique constraint on that table. Duplicate rows are ignored, the rest are inserted. It's fast.
- Preserves the old strategy(ies), under the rubrics SINGLE, CHUNK_BISECT, and ADAPTIVE (the original insert strategy).
- Improves slightly the behaviour of the single-insert function that is resorted to in the worst case. It's still quite slow.
- Allows the user to pick the strategy with the -R/--insert_strategy (-i, -I, S, and may other likely option flags were all taken, so R for inseRt !). Default is BULK.
- Substantially improves the speed of the align phase, by caching None results from the database as well as non-None results. That results in an approximately 50x speedup in the align phase (~30-40 s vs. ~1 hr for ~1 M rows).
- Adds progress logging for the align phase, which was useful for discovering the None/not-None improvement, and which remains interesting and unobtrusive now.

@jameshiebert , if it seems that you have seen some of this code before, you have. I cherry-picked useful commits from #164 (which was most of them) and added the bulk insert feature on top of them. The dangerous time filtering algo is of course not present in this version; all the time filtering code is left unchanged from the mainline. I think it no longer matters if we try to insert large numbers of already-existing records if BULK is used.