### PR TITLE
Clean up cruft in pyproject.toml

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install project
       run: |
-        poetry install
+        poetry install -E jsonlogger
 
     - name: Test with pytest
       env:

--- a/poetry.lock
+++ b/poetry.lock
@@ -895,18 +895,18 @@ xarray = ["xarray"]
 
 [[package]]
 name = "platformdirs"
-version = "3.5.0"
+version = "3.5.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.0-py3-none-any.whl", hash = "sha256:47692bc24c1958e8b0f13dd727307cff1db103fca36399f457da8e05f222fdc4"},
-    {file = "platformdirs-3.5.0.tar.gz", hash = "sha256:7954a68d0ba23558d753f73437c55f89027cf8f5108c19844d4b82e5af396335"},
+    {file = "platformdirs-3.5.1-py3-none-any.whl", hash = "sha256:e2378146f1964972c03c085bb5662ae80b2b8c06226c54b2ff4aa9483e8a13a5"},
+    {file = "platformdirs-3.5.1.tar.gz", hash = "sha256:412dae91f52a6f84830f39a8078cecd0e866cb72294a5c66808e74d5e88d251f"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
+docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.2.1)", "sphinx-autodoc-typehints (>=1.23,!=1.23.4)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
@@ -1139,7 +1139,7 @@ name = "python-json-logger"
 version = "2.0.7"
 description = "A python library adding a json log formatter"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c"},
@@ -1473,4 +1473,4 @@ jsonlogger = ["python-json-logger"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3db933965c8ccaeb21cba096341893d85dea4921185141d74ecd75bc20f33591"
+content-hash = "f5428a5a79d7eba2665429b7eac49453e6e467f4c80d01ac5162da20f9a52287"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,38 +50,22 @@ pycds = { version = "4.3.0", source = "pcic-pypi" }
 pint = "*"
 pysftp = "*"
 # In Python 3.8 and/or possibly on the crmprtd server, if we use a later version of `urllib3`,
-# we end up with an incompatible version of `liburl3` and importing it fails. So we have to pin
-# `urllib3`. This should become a version-dependent constraint if we loosen the `python` constraint
-# above.
+# importing it fails because it dropped support for OpenSSL<1.1.1, which is what we have
+# currently on the crmprtd server. So we have to pin `urllib3`. This should become a
+# version-dependent constraint if we loosen the `python` constraint above. For more details,
+# see https://github.com/pacificclimate/crmprtd/issues/169.
 urllib3 = "<2"
 
-# Optional dependencies, added via the extras facility, using the `jsonlogger` extra
-# defined below.
+# Optional dependencies, added via the extras facility; see below.
 "python-json-logger" = { version = "*", optional = true }
 
 [tool.poetry.extras]
-# This allows installs with extras of the following form
-#   pip install crmprtd[jsonlogger]
-#   poetry install -E jsonlogger
-# and causes the optional package `python-json-logger` to be installed.
 jsonlogger = ["python-json-logger"]
-
-# TODO: Remove, almost certainly unnecessary and possibly wrong.
-# The following allows the user to install `crmprtd` with the `jsonlogger` extra.
-# See https://python-poetry.org/docs/pyproject#extras
-# There may be an easier way to do this. It's not even clear it does this.
-# Going to add it the apparently correct way.
-#[tool.poetry.group.jsonlogger]
-#optional = true
-#
-#[tool.poetry.group.jsonlogger.dependencies]
-#"python-json-logger" = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
 requests_mock = "*"
 pytest-cov = "*"
-python-json-logger = "*"
 "testing.postgresql" = "*"
 pytest-mock = "*"
 black = "*"
@@ -108,10 +92,6 @@ crmprtd_process = "crmprtd.process:main"
 #    "scripts/moti_infill_insert.py",
 #    "scripts/moti_insert_files.py",
 #
-#  Execution scripts. These are deprecated now. If we wish to include them nontheless,
-#  they will have to be added to the [tool.poetry] include key.
+#  Supplementary scripts. Add to the [tool.poetry] include key.
 #
-#    "crmprtd/execution/crmprtd_inserts.sh",
-#    "crmprtd/execution/hourly_swobml2.sh",
 #    "crmprtd/execution/update_matviews_lazy.sql",
-#    "crmprtd/execution/wamr_backpatch_20201118.sh"


### PR DESCRIPTION
Resolves #171

Minor installation change: Previously python-json-logger was both an optional project dep and a required dev dep. Decided to remove this redundancy -- now installs for dev or testing have to ask for the jsonlogger extra.