### PR TITLE
lock paramiko to 3.5.1 to avoid deprecation issues

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install Poetry
       run: |
-        curl -sSL https://install.python-poetry.org | python3 -
+        pipx install poetry==2.1.3
 
     - name: Install project
       run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -1735,4 +1735,4 @@ jsonlogger = ["python-json-logger"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "2af8d31f9e6f619583c5be4ed808d498a62526ebc3c41c800c26ff227e81fc81"
+content-hash = "fd684e508fe5b5b707c1b19a55b16facfd536b9a449428a273a451884ddc3a59"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ requests = { version = "*", extras = ["security"] }
 pycds = "5.0.0"
 pint = "*"
 pysftp = "*"
+# Paramiko 4.0.0 dropped support for DSA keys which are used by pysftp, see https://www.paramiko.org/changelog.html
+paramiko = ">=3.5.1,<4.0.0"
 urllib3 = "<2"
 python-json-logger = { version = "*", optional = true }
 black = "25.1.0"


### PR DESCRIPTION
pysftp hasn't been updated in a long time and relies on importing keys from paramiko what have been deprecated in version 4.0.0 and above. This manually binds the package version to its 3.x.x versions so that we should be able to avoid this until we get around to upgrading or replacing pysftp.

Added an issue for a more permanent replacement in https://github.com/pacificclimate/crmprtd/issues/191